### PR TITLE
fix: update to current overseer.nvim template provider API

### DIFF
--- a/lua/obazel/config/init.lua
+++ b/lua/obazel/config/init.lua
@@ -20,7 +20,7 @@
 ---         templates = {
 ---           {
 ---             args = { "run", "//:gazelle" },
----             template = { name = "bazel run //:gazelle", priority = 50 },
+---             template = { name = "bazel run //:gazelle" },
 ---           },
 ---         },
 ---         -- task templates generated via bazel queries
@@ -30,7 +30,6 @@
 ---             args = { "test" },
 ---             template_file_definition = {
 ---               tags = { "TEST" },
----               priority = 51,
 ---             },
 ---           },
 ---           {
@@ -38,7 +37,6 @@
 ---             args = { "run" },
 ---             template_file_definition = {
 ---               tags = { "RUN" },
----               priority = 52,
 ---             },
 ---           },
 ---           {
@@ -46,7 +44,6 @@
 ---             args = { "build" },
 ---             template_file_definition = {
 ---               tags = { "BUILD" },
----               priority = 100,
 ---             },
 ---           },
 ---         },
@@ -66,11 +63,11 @@
 ---A static template definition for bazel targets that you always want to have
 ---available. For example `bazel run //:gazelle`.
 ---
----Use the `template` argument to set the `name` and `priority` of the task:
+---Use the `template` argument to set the `name` of the task:
 --->lua
 ---     {
 ---         args = { "run", "//:gazelle" },
----         template = { name = "bazel run //:gazelle", priority = 50 },
+---         template = { name = "bazel run //:gazelle" },
 ---     }
 ---@class obazel.TemplateConfig
 ---@field args string[] the args that will be passed to bazel
@@ -90,14 +87,13 @@
 ---       args = { "test" },
 ---       template_file_definition = {
 ---         tags = { "TEST" },
----         priority = 51,
 ---       },
 ---     }
 ---@class obazel.GeneratorConfig
 ---@field query_template string a query template where '%s' will be replaced by the target_prefix
 ---@field args string[] args that will be passed to bazel before the targets
 ---@field template_file_definition? table (optional) overrides values in the base overseer.TemplateFileDefinition
----@see overseer.wrap_template
+---@see overseer.TemplateFileDefinition
 
 ---@type obazel.Config | fun():obazel.Config | nil
 vim.g.obazel = vim.g.obazel

--- a/lua/obazel/init.lua
+++ b/lua/obazel/init.lua
@@ -26,7 +26,6 @@
 ---     }
 ---
 ---See:
----     |overseer.wrap_template|
 ---     https://github.com/stevearc/overseer.nvim/blob/master/doc/guides.md
 
 ---@brief ]]

--- a/lua/overseer/template/obazel/init.lua
+++ b/lua/overseer/template/obazel/init.lua
@@ -8,7 +8,6 @@
 
 local bazel = require("obazel.bazel")
 local config = require("obazel.config.internal")
-local overseer = require("overseer")
 
 local config_is_valid = require("obazel.config.check").validate(config)
 
@@ -20,39 +19,9 @@ local function remove_prefix(str, prefix)
     end
 end
 
----@type overseer.TemplateDefinition
-local base_template = {
-    name = "base",
-    priority = 60,
-    params = {
-        args = { type = "list", delimiter = " " },
-    },
-    builder = function(params)
-        return {
-            cmd = { config.bazel_binary },
-            args = params.args,
-        }
-    end,
-}
-
 ---@type overseer.TemplateProvider
 local provider = {
     name = "bazel",
-}
-
-provider.condition = {
-    callback = function(opts)
-        if not config_is_valid then
-            return false, "Invalid config"
-        end
-        if not bazel.resolve_workspace_file(opts.dir) then
-            return false, "Not in a bazel workspace."
-        end
-        if not bazel.resolve_buildfile(opts.dir) then
-            return false, "No BUILD.bazel file found"
-        end
-        return true
-    end,
 }
 
 ---@param opts overseer.SearchParams
@@ -61,26 +30,33 @@ function provider.cache_key(opts)
 end
 
 function provider.generator(opts, cb)
-    -- Resolve the target prefix for the given directory
+    if not config_is_valid then
+        return "Invalid obazel config"
+    end
+
     local target_prefix, err1 = bazel.resolve_target_prefix(opts.dir)
-    if target_prefix == nil or err1 ~= nil then
-        vim.notify(err1, vim.log.levels.ERROR)
-        cb({})
-        return
+    if err1 ~= nil then
+        return err1
     end
 
     ---@type overseer.TemplateDefinition[]
     local templates = {}
 
-    -- Set up static templates
     for _, template_config in ipairs(config.overseer.templates) do
+        local args = template_config.args
         table.insert(
             templates,
-            overseer.wrap_template(base_template, template_config.template, { args = template_config.args })
+            vim.tbl_deep_extend("force", {
+                builder = function()
+                    return {
+                        cmd = { config.bazel_binary },
+                        args = args,
+                    }
+                end,
+            }, template_config.template)
         )
     end
 
-    -- Generate templates through bazel queries
     for _, query_config in ipairs(config.overseer.generators) do
         local query = query_config.query_template:format(target_prefix)
 
@@ -91,19 +67,19 @@ function provider.generator(opts, cb)
             for _, target in ipairs(targets) do
                 -- TODO toggleable in config to show short or long targets?
                 local short_target = remove_prefix(target, target_prefix)
-
-                ---@type overseer.TemplateDefinition
-                local template = vim.tbl_deep_extend(
-                    "force",
-                    { name = ("bazel %s %s"):format(table.concat(query_config.args, " "), short_target) },
-                    query_config.template_file_definition ~= nil and query_config.template_file_definition or {}
-                )
+                local qargs = vim.list_extend(vim.deepcopy(query_config.args), { target })
 
                 table.insert(
                     templates,
-                    overseer.wrap_template(base_template, template, {
-                        args = { unpack(query_config.args), target },
-                    })
+                    vim.tbl_deep_extend("force", {
+                        name = ("bazel %s %s"):format(table.concat(query_config.args, " "), short_target),
+                        builder = function()
+                            return {
+                                cmd = { config.bazel_binary },
+                                args = qargs,
+                            }
+                        end,
+                    }, query_config.template_file_definition or {})
                 )
             end
         end


### PR DESCRIPTION
- Replace `overseer.wrap_template` (removed upstream) with direct `TemplateDefinition` construction using builder closures
- Remove `condition.callback` (no longer supported); move workspace/config checks into the generator
- Drop `priority` field from templates and docs (removed upstream)

Fixes #9. Fixes #10.