### PR TITLE
fix: run `bazel query` asynchronously to avoid blocking the UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,34 @@ require("overseer").setup({
 The template provider does not come with any default templates. They must be
 configured through the `vim.g.obazel` table.
 
+> [!WARNING]
+> obazel.nvim runs `bazel query` asynchronously when populating the task list,
+> which avoids freezing the UI while the query runs. However, overseer.nvim
+> imposes a default timeout of 3000ms (`template_timeout_ms`) on template
+> providers; if the Bazel server is not yet running or the workspace is large,
+> the query may not complete in time and `:OverseerRun` may silently show no
+> results from obazel.nvim.
+
+If `:OverseerRun` doesn't seem to do anything on first run, or your picker
+doesn't show any obazel-configured tasks, try increasing the timeout in your overseer setup:
+
+```lua
+require("overseer").setup({
+    template_timeout_ms = 10000,
+})
+```
+
+Alternatively, you can pre-warm the cache when a buffer is opened so the query
+runs in the background before you invoke `:OverseerRun`:
+
+```lua
+vim.api.nvim_create_autocmd("BufEnter", {
+    callback = function()
+        require("overseer").preload_task_cache()
+    end,
+})
+```
+
 ### Example Configuration
 
 ```lua

--- a/lua/obazel/bazel.lua
+++ b/lua/obazel/bazel.lua
@@ -102,31 +102,36 @@ function bazel.resolve_target_prefix(directory)
     return "//" .. (relpath == "." and "" or relpath)
 end
 
----Run a bazel query
+---Run a bazel query asynchronously
 ---@param query string
----@return string[] targets
----@return nil|string error_message
----@usage `bazel.query("//foo/bar/...")`
-function bazel.query(query)
-    local obj = vim.system({ config.bazel_binary, "query", query }, { text = true }):wait()
+---@param callback fun(targets: string[], error_message: string|nil)
+---@usage `bazel.query("//foo/bar/...", function(targets, err) ... end)`
+function bazel.query(query, callback)
+    vim.system(
+        { config.bazel_binary, "query", query },
+        { text = true },
+        vim.schedule_wrap(function(obj)
+            -- TODO this is weird behavior that will hopefully get fixed
+            -- https://github.com/neovim/neovim/pull/26917
+            if obj == nil then
+                callback({}, "failed to execute query")
+                return
+            end
 
-    -- TODO this is weird behavior that will hopefully get fixed
-    -- https://github.com/neovim/neovim/pull/26917
-    if obj == nil then
-        return {}, "failed to execute query"
-    end
+            if obj.code ~= 0 then
+                vim.notify(("[stdout]:\n%s\n[stderr]:\n%s"):format(obj.stdout, obj.stderr), vim.log.levels.ERROR)
+                callback({}, "failed to execute query: code=" .. obj.code .. " signal=" .. obj.signal)
+                return
+            end
 
-    if obj.code ~= 0 then
-        vim.notify(("[stdout]:\n%s\n[stderr]:\n%s"):format(obj.stdout, obj.stderr), vim.log.levels.ERROR)
-        return {}, "failed to execute query: code=" .. obj.code .. " signal=" .. obj.signal
-    end
-
-    local targets = {}
-    local lines = vim.split(obj.stdout, "\n", { plain = true, trimempty = true })
-    for _, line in ipairs(lines) do
-        table.insert(targets, line)
-    end
-    return targets
+            local targets = {}
+            local lines = vim.split(obj.stdout, "\n", { plain = true, trimempty = true })
+            for _, line in ipairs(lines) do
+                table.insert(targets, line)
+            end
+            callback(targets, nil)
+        end)
+    )
 end
 
 return bazel

--- a/lua/overseer/template/obazel/init.lua
+++ b/lua/overseer/template/obazel/init.lua
@@ -57,35 +57,46 @@ function provider.generator(opts, cb)
         )
     end
 
-    for _, query_config in ipairs(config.overseer.generators) do
-        local query = query_config.query_template:format(target_prefix)
+    local generators = config.overseer.generators
+    local pending = #generators
 
-        local targets, err2 = bazel.query(query)
-        if err2 ~= nil then
-            vim.notify(err2, vim.log.levels.ERROR)
-        else
-            for _, target in ipairs(targets) do
-                -- TODO toggleable in config to show short or long targets?
-                local short_target = remove_prefix(target, target_prefix)
-                local qargs = vim.list_extend(vim.deepcopy(query_config.args), { target })
-
-                table.insert(
-                    templates,
-                    vim.tbl_deep_extend("force", {
-                        name = ("bazel %s %s"):format(table.concat(query_config.args, " "), short_target),
-                        builder = function()
-                            return {
-                                cmd = { config.bazel_binary },
-                                args = qargs,
-                            }
-                        end,
-                    }, query_config.template_file_definition or {})
-                )
-            end
-        end
+    if pending == 0 then
+        cb(templates)
+        return
     end
 
-    cb(templates)
+    for _, query_config in ipairs(generators) do
+        local query = query_config.query_template:format(target_prefix)
+
+        bazel.query(query, function(targets, err2)
+            if err2 ~= nil then
+                vim.notify(err2, vim.log.levels.ERROR)
+            else
+                for _, target in ipairs(targets) do
+                    -- TODO toggleable in config to show short or long targets?
+                    local short_target = remove_prefix(target, target_prefix)
+                    local qargs = vim.list_extend(vim.deepcopy(query_config.args), { target })
+
+                    table.insert(
+                        templates,
+                        vim.tbl_deep_extend("force", {
+                            name = ("bazel %s %s"):format(table.concat(query_config.args, " "), short_target),
+                            builder = function()
+                                return {
+                                    cmd = { config.bazel_binary },
+                                    args = qargs,
+                                }
+                            end,
+                        }, query_config.template_file_definition or {})
+                    )
+                end
+            end
+            pending = pending - 1
+            if pending == 0 then
+                cb(templates)
+            end
+        end)
+    end
 end
 
 return provider


### PR DESCRIPTION
Convert `bazel.query` from a blocking `vim.system():wait()` call to an async `on_exit` callback. The template generator is updated to accumulate results across all concurrent queries and call `cb()` once all are done.

Wrap the `on_exit` handler with `vim.schedule_wrap` so that overseer callbacks (which call Vimscript functions like `inputlist`) are invoked in the main event loop rather than the libuv fast-event context.

Fixes #7.