### PR TITLE
feat!: replace vim.g.obazel with require("obazel").setup()

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,13 @@ An [overseer.nvim](https://github.com/stevearc/overseer.nvim) template provider 
 
 ## Configuration
 
-The template provider needs to be registered with overseer:
+obazel.nvim is configured by calling `require("obazel").setup({...})`, and
+the template provider needs to be registered with overseer:
 
 ```lua
+require("obazel").setup({
+    -- see "Example Configuration" below
+})
 require("overseer").setup({
     templates = {
         "builtin",
@@ -36,8 +40,12 @@ require("overseer").setup({
 }
 ```
 
+`obazel.setup()` must run before overseer collects templates (e.g. before
+`:OverseerRun` or `preload_task_cache()` is invoked), so call it as part of
+your plugin configuration.
+
 The template provider does not come with any default templates. They must be
-configured through the `vim.g.obazel` table.
+configured through `obazel.setup()`.
 
 > [!WARNING]
 > obazel.nvim runs `bazel query` asynchronously when populating the task list,
@@ -71,8 +79,7 @@ vim.api.nvim_create_autocmd("BufEnter", {
 
 ```lua
 ---@module 'obazel'
----@type obazel.Config
-vim.g.obazel = {
+require("obazel").setup({
   -- (optional) The binary used to invoke bazel commands
   -- bazel_binary = "bazel",
   overseer = {
@@ -133,7 +140,7 @@ vim.g.obazel = {
       },
     },
   },
-}
+})
 ```
 
 Each entry in `templates`/`generators` also accepts `args`, `after_target_args`,

--- a/README.md
+++ b/README.md
@@ -82,6 +82,17 @@ vim.g.obazel = {
         args = { "run", "//:gazelle" },
         template = { name = "bazel run //:gazelle", priority = 50 },
       },
+      {
+        args = { "test", "//..." },
+        -- Appended after the target (unlike `args`, which comes before it),
+        -- e.g. for flags you want passed through to the test binary itself
+        -- via `--`.
+        after_target_args = { "--", "--some-flag" },
+        env = { BAZEL_CONFIG = "ci" },
+        metadata = { kind = "test" },
+        components = { "default", { "on_output_parse", errorformat = "..." } },
+        template = { name = "bazel test //..." },
+      },
     },
     -- Task templates generated via bazel queries. The '%s' sign in the
     -- query_template will be replaced with the target_prefix, which is the
@@ -115,3 +126,18 @@ vim.g.obazel = {
   },
 }
 ```
+
+Each entry in `templates`/`generators` also accepts `after_target_args`, `env`,
+`metadata`, and `components`, which are merged into the
+`overseer.TaskDefinition` produced for that template/generated task (see
+`obazel.TemplateConfig` and `obazel.GeneratorConfig`). These are distinct
+from `template`/`template_file_definition`, which only affect the
+`overseer.TemplateDefinition` shown in `:OverseerRun`; fields like
+`components`, `env`, and `metadata` have no effect there, since they belong
+to the task, not the template.
+
+The name of a generated task (from `generators`, not `templates`) starts
+with the tail of `config.bazel_binary` (e.g. `/usr/bin/bazelisk` becomes
+`bazelisk`), followed by `args`, the resolved target, and `after_target_args`,
+so task names stay accurate and distinct even when `bazel_binary` or
+`after_target_args` differ between generator entries.

--- a/README.md
+++ b/README.md
@@ -137,10 +137,11 @@ vim.g.obazel = {
 ```
 
 Each entry in `templates`/`generators` also accepts `args`, `after_target_args`,
-`binary`, `cwd`, `env`, `metadata`, and `components`, which are merged into
-the `overseer.TaskDefinition` produced for that template/generated task (see
-`obazel.TemplateConfig` and `obazel.GeneratorConfig`). These are distinct
-from `template`/`template_file_definition`, which only affect the
+`binary`, `cwd`, `env`, `metadata`, `components`, and `relative_file_root`,
+which are merged into the `overseer.TaskDefinition` produced for that
+template/generated task (see `obazel.TemplateConfig` and
+`obazel.GeneratorConfig`). These are distinct from
+`template`/`template_file_definition`, which only affect the
 `overseer.TemplateDefinition` shown in `:OverseerRun`; fields like
 `components`, `env`, and `metadata` have no effect there, since they belong
 to the task, not the template. `args` and `binary` are both optional:
@@ -148,10 +149,12 @@ omitting `args` produces a command with none (just `binary target` for
 generators), and omitting `binary` falls back to the top-level
 `bazel_binary`.
 
-`cwd` sets the task's working directory. It defaults to the resolved bazel
-workspace root, and can be overridden with a fixed string or a function that
-takes the workspace root and returns the directory to use, e.g. to fall
-back to Neovim's own cwd instead:
+`cwd` sets the task's working directory, and `relative_file_root` is used to
+resolve relative paths reported by components like `on_output_parse` (e.g.
+compiler diagnostics). Both default to the resolved bazel workspace root, and
+both can be overridden with a fixed string or a function that takes the
+workspace root and returns the path to use, e.g. to fall back to Neovim's
+own cwd instead:
 
 ```lua
 {
@@ -162,6 +165,14 @@ back to Neovim's own cwd instead:
   template = { name = "bazel run //:gazelle" },
 }
 ```
+
+`relative_file_root` is resolved independently of `cwd`, and does *not* fall
+back to task `cwd` when left unset the way overseer's own `relative_file_root`
+component param does. Bazel's own diagnostics are reported relative to the
+workspace root regardless of where the task actually runs, so if you override
+`cwd` (e.g. to run a task from Neovim's cwd, as above) without also touching
+`relative_file_root`, diagnostics still resolve against the workspace root,
+which is almost always what you want.
 
 The name of a generated task (from `generators`, not `templates`) starts
 with the tail of `binary` (its own `binary` if set, otherwise the tail of
@@ -175,8 +186,8 @@ Because `template`/`template_file_definition` are plain
 can also supply your own `builder` there to fully replace obazel's. Doing so
 still gives you access to everything obazel would otherwise have used to
 build the task: `binary`, `args`, `after_target_args`, `cwd`, `env`, `metadata`,
-`components`, and (for `generators` only) the resolved `target`, via the
-`params` argument overseer passes to `builder(params)`:
+`components`, `relative_file_root`, and (for `generators` only) the resolved
+`target`, via the `params` argument overseer passes to `builder(params)`:
 
 ```lua
 {

--- a/README.md
+++ b/README.md
@@ -122,22 +122,59 @@ vim.g.obazel = {
           priority = 100,
         },
       },
+      {
+        -- `args` is optional; omitting it produces just "binary target",
+        -- e.g. for a custom wrapper script that takes a target directly.
+        query_template = "kind(rule, %s:*)",
+        binary = "foo",
+        template_file_definition = {
+          tags = { "FOO" },
+        },
+      },
     },
   },
 }
 ```
 
-Each entry in `templates`/`generators` also accepts `after_target_args`, `env`,
-`metadata`, and `components`, which are merged into the
+Each entry in `templates`/`generators` also accepts `args`, `after_target_args`,
+`binary`, `env`, `metadata`, and `components`, which are merged into the
 `overseer.TaskDefinition` produced for that template/generated task (see
 `obazel.TemplateConfig` and `obazel.GeneratorConfig`). These are distinct
 from `template`/`template_file_definition`, which only affect the
 `overseer.TemplateDefinition` shown in `:OverseerRun`; fields like
 `components`, `env`, and `metadata` have no effect there, since they belong
-to the task, not the template.
+to the task, not the template. `args` and `binary` are both optional:
+omitting `args` produces a command with none (just `binary target` for
+generators), and omitting `binary` falls back to the top-level
+`bazel_binary`.
 
 The name of a generated task (from `generators`, not `templates`) starts
-with the tail of `config.bazel_binary` (e.g. `/usr/bin/bazelisk` becomes
-`bazelisk`), followed by `args`, the resolved target, and `after_target_args`,
-so task names stay accurate and distinct even when `bazel_binary` or
+with the tail of `binary` (its own `binary` if set, otherwise the tail of
+`config.bazel_binary`, e.g. `/usr/bin/bazelisk` becomes `bazelisk`),
+followed by `args`, the resolved target, and `after_target_args`, so task
+names stay accurate and distinct even when `binary`, `args`, or
 `after_target_args` differ between generator entries.
+
+Because `template`/`template_file_definition` are plain
+`overseer.TemplateDefinition`/`overseer.TemplateFileDefinition` tables, you
+can also supply your own `builder` there to fully replace obazel's. Doing so
+still gives you access to everything obazel would otherwise have used to
+build the task: `binary`, `args`, `after_target_args`, `env`, `metadata`,
+`components`, and (for `generators` only) the resolved `target`, via the
+`params` argument overseer passes to `builder(params)`:
+
+```lua
+{
+  query_template = "tests(%s:*)",
+  args = { "test" },
+  template_file_definition = {
+    builder = function(params)
+      return {
+        cmd = { params.binary },
+        args = { "test", params.target, "--test_output=all" },
+        env = params.env,
+      }
+    end,
+  },
+}
+```

--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ vim.g.obazel = {
 ```
 
 Each entry in `templates`/`generators` also accepts `args`, `after_target_args`,
-`binary`, `env`, `metadata`, and `components`, which are merged into the
-`overseer.TaskDefinition` produced for that template/generated task (see
+`binary`, `cwd`, `env`, `metadata`, and `components`, which are merged into
+the `overseer.TaskDefinition` produced for that template/generated task (see
 `obazel.TemplateConfig` and `obazel.GeneratorConfig`). These are distinct
 from `template`/`template_file_definition`, which only affect the
 `overseer.TemplateDefinition` shown in `:OverseerRun`; fields like
@@ -147,6 +147,21 @@ to the task, not the template. `args` and `binary` are both optional:
 omitting `args` produces a command with none (just `binary target` for
 generators), and omitting `binary` falls back to the top-level
 `bazel_binary`.
+
+`cwd` sets the task's working directory. It defaults to the resolved bazel
+workspace root, and can be overridden with a fixed string or a function that
+takes the workspace root and returns the directory to use, e.g. to fall
+back to Neovim's own cwd instead:
+
+```lua
+{
+  args = { "run", "//:gazelle" },
+  cwd = function(workspace_root)
+    return vim.fn.getcwd()
+  end,
+  template = { name = "bazel run //:gazelle" },
+}
+```
 
 The name of a generated task (from `generators`, not `templates`) starts
 with the tail of `binary` (its own `binary` if set, otherwise the tail of
@@ -159,7 +174,7 @@ Because `template`/`template_file_definition` are plain
 `overseer.TemplateDefinition`/`overseer.TemplateFileDefinition` tables, you
 can also supply your own `builder` there to fully replace obazel's. Doing so
 still gives you access to everything obazel would otherwise have used to
-build the task: `binary`, `args`, `after_target_args`, `env`, `metadata`,
+build the task: `binary`, `args`, `after_target_args`, `cwd`, `env`, `metadata`,
 `components`, and (for `generators` only) the resolved `target`, via the
 `params` argument overseer passes to `builder(params)`:
 

--- a/doc/obazel.nvim.txt
+++ b/doc/obazel.nvim.txt
@@ -111,10 +111,11 @@ Example configuration
      }
 
 Each entry in `templates`/`generators` also accepts `args`, `after_target_args`,
-`binary`, `cwd`, `env`, `metadata`, and `components`, which are merged into
-the |overseer.TaskDefinition| produced for that template/generated task (see
-|obazel.TemplateConfig| and |obazel.GeneratorConfig|). These are distinct
-from `template`/`template_file_definition`, which only affect the
+`binary`, `cwd`, `env`, `metadata`, `components`, and `relative_file_root`,
+which are merged into the |overseer.TaskDefinition| produced for that
+template/generated task (see |obazel.TemplateConfig| and
+|obazel.GeneratorConfig|). These are distinct from
+`template`/`template_file_definition`, which only affect the
 |overseer.TemplateDefinition| shown in |:OverseerRun|; fields like
 `components`, `env`, and `metadata` have no effect there, since they belong
 to the task, not the template. `args` and `binary` are both optional:
@@ -122,10 +123,12 @@ omitting `args` produces a command with none (just `binary target` for
 generators), and omitting `binary` falls back to the top-level
 `bazel_binary`.
 
-`cwd` sets the task's working directory. It defaults to the resolved bazel
-workspace root, and can be overridden with a fixed string or a function that
-takes the workspace root and returns the directory to use, e.g. to fall
-back to Neovim's own cwd instead:
+`cwd` sets the task's working directory, and `relative_file_root` is used to
+resolve relative paths reported by components like `on_output_parse` (e.g.
+compiler diagnostics). Both default to the resolved bazel workspace root, and
+both can be overridden with a fixed string or a function that takes the
+workspace root and returns the path to use, e.g. to fall back to Neovim's
+own cwd instead:
 >lua
      {
        args = { "run", "//:gazelle" },
@@ -135,6 +138,14 @@ back to Neovim's own cwd instead:
        template = { name = "bazel run //:gazelle" },
      }
 <
+`relative_file_root` is resolved independently of `cwd`, and does *not* fall
+back to task `cwd` when left unset the way overseer's own `relative_file_root`
+component param does. Bazel's own diagnostics are reported relative to the
+workspace root regardless of where the task actually runs, so if you override
+`cwd` (e.g. to run a task from Neovim's cwd, as above) without also touching
+`relative_file_root`, diagnostics still resolve against the workspace root,
+which is almost always what you want.
+
 The name of a generated task (from `generators`, not `templates`) starts
 with the tail of `binary` (its own `binary` if set, otherwise the tail of
 `config.bazel_binary`, e.g. `/usr/bin/bazelisk` becomes `bazelisk`),
@@ -147,8 +158,8 @@ Because `template`/`template_file_definition` are plain
 can also supply your own `builder` there to fully replace obazel's. Doing so
 still gives you access to everything obazel would otherwise have used to
 build the task: `binary`, `args`, `after_target_args`, `cwd`, `env`, `metadata`,
-`components`, and (for `generators` only) the resolved `target`, via the
-`params` argument overseer passes to `builder(params)`:
+`components`, `relative_file_root`, and (for `generators` only) the resolved
+`target`, via the `params` argument overseer passes to `builder(params)`:
 >lua
      {
        query_template = "tests(%s:*)",
@@ -198,6 +209,7 @@ obazel.TemplateConfig                                    *obazel.TemplateConfig*
         {env?}                (table<string,string>)         (optional) environment variables for the task
         {metadata?}      (table)                        (optional) arbitrary metadata for the task
         {components?}    (overseer.Serialized[])        (optional) overseer components for the task
+        {relative_file_root?} (string|fun(workspace_root: string): string) (optional) root for resolving relative paths reported by output-parsing components (e.g. compiler diagnostics), or a function of the resolved bazel workspace root that returns one; defaults to the workspace root. Unlike overseer's own `relative_file_root` param, this does *not* fall back to task `cwd` when unset: bazel's own diagnostics are reported relative to the workspace root regardless of `cwd`, so obazel pins this independently rather than letting it silently track a `cwd` override.
         {template}       (overseer.TemplateDefinition)  the template definition
 
 
@@ -229,6 +241,7 @@ obazel.GeneratorConfig                                  *obazel.GeneratorConfig*
         {env?}                       (table<string,string>)    (optional) environment variables for generated tasks
         {metadata?}                  (table)                   (optional) arbitrary metadata for generated tasks
         {components?}                (overseer.Serialized[])   (optional) overseer components for generated tasks
+        {relative_file_root?}        (string|fun(workspace_root: string): string) (optional) root for resolving relative paths reported by output-parsing components (e.g. compiler diagnostics), or a function of the resolved bazel workspace root that returns one; defaults to the workspace root. Unlike overseer's own `relative_file_root` param, this does *not* fall back to task `cwd` when unset: bazel's own diagnostics are reported relative to the workspace root regardless of `cwd`, so obazel pins this independently rather than letting it silently track a `cwd` override.
         {template_file_definition?}  (table)                   (optional) overrides values in the base overseer.TemplateFileDefinition
 
     See: ~

--- a/doc/obazel.nvim.txt
+++ b/doc/obazel.nvim.txt
@@ -111,8 +111,8 @@ Example configuration
      }
 
 Each entry in `templates`/`generators` also accepts `args`, `after_target_args`,
-`binary`, `env`, `metadata`, and `components`, which are merged into the
-|overseer.TaskDefinition| produced for that template/generated task (see
+`binary`, `cwd`, `env`, `metadata`, and `components`, which are merged into
+the |overseer.TaskDefinition| produced for that template/generated task (see
 |obazel.TemplateConfig| and |obazel.GeneratorConfig|). These are distinct
 from `template`/`template_file_definition`, which only affect the
 |overseer.TemplateDefinition| shown in |:OverseerRun|; fields like
@@ -122,6 +122,19 @@ omitting `args` produces a command with none (just `binary target` for
 generators), and omitting `binary` falls back to the top-level
 `bazel_binary`.
 
+`cwd` sets the task's working directory. It defaults to the resolved bazel
+workspace root, and can be overridden with a fixed string or a function that
+takes the workspace root and returns the directory to use, e.g. to fall
+back to Neovim's own cwd instead:
+>lua
+     {
+       args = { "run", "//:gazelle" },
+       cwd = function(workspace_root)
+         return vim.fn.getcwd()
+       end,
+       template = { name = "bazel run //:gazelle" },
+     }
+<
 The name of a generated task (from `generators`, not `templates`) starts
 with the tail of `binary` (its own `binary` if set, otherwise the tail of
 `config.bazel_binary`, e.g. `/usr/bin/bazelisk` becomes `bazelisk`),
@@ -133,7 +146,7 @@ Because `template`/`template_file_definition` are plain
 |overseer.TemplateDefinition|/|overseer.TemplateFileDefinition| tables, you
 can also supply your own `builder` there to fully replace obazel's. Doing so
 still gives you access to everything obazel would otherwise have used to
-build the task: `binary`, `args`, `after_target_args`, `env`, `metadata`,
+build the task: `binary`, `args`, `after_target_args`, `cwd`, `env`, `metadata`,
 `components`, and (for `generators` only) the resolved `target`, via the
 `params` argument overseer passes to `builder(params)`:
 >lua
@@ -181,6 +194,7 @@ obazel.TemplateConfig                                    *obazel.TemplateConfig*
         {args?}               (string[])                     (optional) the args that will be passed to bazel; omit for none, e.g. `binary target`
         {after_target_args?}  (string[])                     (optional) args appended after `args`, e.g. for flags to pass through to the target itself via `--`
         {binary?}             (string)                       (optional) override the configured `bazel_binary` for this template
+        {cwd?}                (string|fun(workspace_root: string): string) (optional) task working directory, or a function of the resolved bazel workspace root that returns one; defaults to the workspace root
         {env?}                (table<string,string>)         (optional) environment variables for the task
         {metadata?}      (table)                        (optional) arbitrary metadata for the task
         {components?}    (overseer.Serialized[])        (optional) overseer components for the task
@@ -211,6 +225,7 @@ obazel.GeneratorConfig                                  *obazel.GeneratorConfig*
         {args?}                      (string[])                (optional) args that will be passed to bazel before the targets; omit for none, e.g. `binary target`
         {after_target_args?}         (string[])                (optional) args appended after the resolved target, e.g. for flags to pass through to the target itself via `--`
         {binary?}                    (string)                  (optional) override the configured `bazel_binary` for generated tasks
+        {cwd?}                       (string|fun(workspace_root: string): string) (optional) task working directory, or a function of the resolved bazel workspace root that returns one; defaults to the workspace root
         {env?}                       (table<string,string>)    (optional) environment variables for generated tasks
         {metadata?}                  (table)                   (optional) arbitrary metadata for generated tasks
         {components?}                (overseer.Serialized[])   (optional) overseer components for generated tasks

--- a/doc/obazel.nvim.txt
+++ b/doc/obazel.nvim.txt
@@ -14,16 +14,18 @@ If there are targets that should always be available regardless of the
 current open file, for example `bazel run //:gazelle`, they can be
 configured as static templates.
 
-See |obazel-nvim.config| for an example configuration.
-
-The template provider will need to be registered with overseer:
+Call |obazel.setup()| to configure obazel.nvim, then register the template
+provider with overseer:
 >lua
+     require("obazel").setup({ ... })
      require("overseer").setup({
          templates = {
              "builtin",
              "obazel",
          },
      }
+
+See |obazel-nvim.config| for an example configuration.
 
 See:
      |overseer.wrap_template|
@@ -36,6 +38,14 @@ obazel.nvim ··································
 obazel.nvim configuration ································· |obazel-nvim.config|
 Bazel utilities ············································ |obazel-nvim.bazel|
 
+obazel.setup({opts?})                                        *obazel-nvim.setup*
+    Configure obazel.nvim. Must be called before overseer.nvim collects
+    templates (e.g. via |:OverseerRun| or `preload_task_cache()`).
+
+    Parameters: ~
+        {opts?}  (obazel.Config)
+
+
 ==============================================================================
 obazel.nvim configuration                                   *obazel-nvim.config*
 
@@ -47,8 +57,7 @@ generators see |obazel.GeneratorConfig|. No templates are defined by default.
 Example configuration
 >lua
      ---@module 'obazel'
-     ---@type obazel.Config
-     vim.g.obazel = {
+     require("obazel").setup({
        -- (optional) The binary used to invoke bazel commands
        bazel_binary = "bazel",
        overseer = {
@@ -108,7 +117,13 @@ Example configuration
            },
          },
        },
-     }
+     })
+
+In prior versions, obazel was configured with a `vim.g.obazel` variable.
+Values assigned to `vim.g` are round-tripped through Vimscript, which has no
+way to represent a table like `{ "on_output_parse", errorformat = "..." }`
+that mixes array and hash parts, so overseer components could never be
+configured this way under the old scheme.
 
 Each entry in `templates`/`generators` also accepts `args`, `after_target_args`,
 `binary`, `cwd`, `env`, `metadata`, `components`, and `relative_file_root`,

--- a/doc/obazel.nvim.txt
+++ b/doc/obazel.nvim.txt
@@ -96,24 +96,60 @@ Example configuration
                priority = 100,
              },
            },
+           {
+             -- `args` is optional; omitting it produces just "binary
+             -- target", e.g. for a custom wrapper script that takes a
+             -- target directly.
+             query_template = "kind(rule, %s:*)",
+             binary = "foo",
+             template_file_definition = {
+               tags = { "FOO" },
+             },
+           },
          },
        },
      }
 
-Each entry in `templates`/`generators` also accepts `after_target_args`, `env`,
-`metadata`, and `components`, which are merged into the
+Each entry in `templates`/`generators` also accepts `args`, `after_target_args`,
+`binary`, `env`, `metadata`, and `components`, which are merged into the
 |overseer.TaskDefinition| produced for that template/generated task (see
 |obazel.TemplateConfig| and |obazel.GeneratorConfig|). These are distinct
 from `template`/`template_file_definition`, which only affect the
 |overseer.TemplateDefinition| shown in |:OverseerRun|; fields like
 `components`, `env`, and `metadata` have no effect there, since they belong
-to the task, not the template.
+to the task, not the template. `args` and `binary` are both optional:
+omitting `args` produces a command with none (just `binary target` for
+generators), and omitting `binary` falls back to the top-level
+`bazel_binary`.
 
 The name of a generated task (from `generators`, not `templates`) starts
-with the tail of `config.bazel_binary` (e.g. `/usr/bin/bazelisk` becomes
-`bazelisk`), followed by `args`, the resolved target, and `after_target_args`,
-so task names stay accurate and distinct even when `bazel_binary` or
+with the tail of `binary` (its own `binary` if set, otherwise the tail of
+`config.bazel_binary`, e.g. `/usr/bin/bazelisk` becomes `bazelisk`),
+followed by `args`, the resolved target, and `after_target_args`, so task
+names stay accurate and distinct even when `binary`, `args`, or
 `after_target_args` differ between generator entries.
+
+Because `template`/`template_file_definition` are plain
+|overseer.TemplateDefinition|/|overseer.TemplateFileDefinition| tables, you
+can also supply your own `builder` there to fully replace obazel's. Doing so
+still gives you access to everything obazel would otherwise have used to
+build the task: `binary`, `args`, `after_target_args`, `env`, `metadata`,
+`components`, and (for `generators` only) the resolved `target`, via the
+`params` argument overseer passes to `builder(params)`:
+>lua
+     {
+       query_template = "tests(%s:*)",
+       args = { "test" },
+       template_file_definition = {
+         builder = function(params)
+           return {
+             cmd = { params.binary },
+             args = { "test", params.target, "--test_output=all" },
+             env = params.env,
+           }
+         end,
+       },
+     }
 
 
 obazel.Config                                                    *obazel.Config*
@@ -142,9 +178,10 @@ obazel.TemplateConfig                                    *obazel.TemplateConfig*
          }
 
     Fields: ~
-        {args}           (string[])                     the args that will be passed to bazel
-        {after_target_args?} (string[])                     (optional) args appended after `args`, e.g. for flags to pass through to the target itself via `--`
-        {env?}           (table<string,string>)        (optional) environment variables for the task
+        {args?}               (string[])                     (optional) the args that will be passed to bazel; omit for none, e.g. `binary target`
+        {after_target_args?}  (string[])                     (optional) args appended after `args`, e.g. for flags to pass through to the target itself via `--`
+        {binary?}             (string)                       (optional) override the configured `bazel_binary` for this template
+        {env?}                (table<string,string>)         (optional) environment variables for the task
         {metadata?}      (table)                        (optional) arbitrary metadata for the task
         {components?}    (overseer.Serialized[])        (optional) overseer components for the task
         {template}       (overseer.TemplateDefinition)  the template definition
@@ -171,8 +208,9 @@ obazel.GeneratorConfig                                  *obazel.GeneratorConfig*
 
     Fields: ~
         {query_template}             (string)                  a query template where '%s' will be replaced by the target_prefix
-        {args}                       (string[])                args that will be passed to bazel before the targets
-        {after_target_args?}             (string[])                (optional) args appended after the resolved target, e.g. for flags to pass through to the target itself via `--`
+        {args?}                      (string[])                (optional) args that will be passed to bazel before the targets; omit for none, e.g. `binary target`
+        {after_target_args?}         (string[])                (optional) args appended after the resolved target, e.g. for flags to pass through to the target itself via `--`
+        {binary?}                    (string)                  (optional) override the configured `bazel_binary` for generated tasks
         {env?}                       (table<string,string>)    (optional) environment variables for generated tasks
         {metadata?}                  (table)                   (optional) arbitrary metadata for generated tasks
         {components?}                (overseer.Serialized[])   (optional) overseer components for generated tasks

--- a/doc/obazel.nvim.txt
+++ b/doc/obazel.nvim.txt
@@ -58,6 +58,17 @@ Example configuration
              args = { "run", "//:gazelle" },
              template = { name = "bazel run //:gazelle", priority = 50 },
            },
+           {
+             args = { "test", "//..." },
+             -- Appended after the target (unlike `args`, which comes before
+             -- it), e.g. for flags you want passed through to the test
+             -- binary itself via `--`.
+             after_target_args = { "--", "--some-flag" },
+             env = { BAZEL_CONFIG = "ci" },
+             metadata = { kind = "test" },
+             components = { "default", { "on_output_parse", errorformat = "..." } },
+             template = { name = "bazel test //..." },
+           },
          },
          -- task templates generated via bazel queries
          generators = {
@@ -89,6 +100,21 @@ Example configuration
        },
      }
 
+Each entry in `templates`/`generators` also accepts `after_target_args`, `env`,
+`metadata`, and `components`, which are merged into the
+|overseer.TaskDefinition| produced for that template/generated task (see
+|obazel.TemplateConfig| and |obazel.GeneratorConfig|). These are distinct
+from `template`/`template_file_definition`, which only affect the
+|overseer.TemplateDefinition| shown in |:OverseerRun|; fields like
+`components`, `env`, and `metadata` have no effect there, since they belong
+to the task, not the template.
+
+The name of a generated task (from `generators`, not `templates`) starts
+with the tail of `config.bazel_binary` (e.g. `/usr/bin/bazelisk` becomes
+`bazelisk`), followed by `args`, the resolved target, and `after_target_args`,
+so task names stay accurate and distinct even when `bazel_binary` or
+`after_target_args` differ between generator entries.
+
 
 obazel.Config                                                    *obazel.Config*
 
@@ -116,8 +142,12 @@ obazel.TemplateConfig                                    *obazel.TemplateConfig*
          }
 
     Fields: ~
-        {args}      (string[])                     the args that will be passed to bazel
-        {template}  (overseer.TemplateDefinition)  the template definition
+        {args}           (string[])                     the args that will be passed to bazel
+        {after_target_args?} (string[])                     (optional) args appended after `args`, e.g. for flags to pass through to the target itself via `--`
+        {env?}           (table<string,string>)        (optional) environment variables for the task
+        {metadata?}      (table)                        (optional) arbitrary metadata for the task
+        {components?}    (overseer.Serialized[])        (optional) overseer components for the task
+        {template}       (overseer.TemplateDefinition)  the template definition
 
 
 obazel.GeneratorConfig                                  *obazel.GeneratorConfig*
@@ -140,9 +170,13 @@ obazel.GeneratorConfig                                  *obazel.GeneratorConfig*
          }
 
     Fields: ~
-        {query_template}             (string)    a query template where '%s' will be replaced by the target_prefix
-        {args}                       (string[])  args that will be passed to bazel before the targets
-        {template_file_definition?}  (table)     (optional) overrides values in the base overseer.TemplateFileDefinition
+        {query_template}             (string)                  a query template where '%s' will be replaced by the target_prefix
+        {args}                       (string[])                args that will be passed to bazel before the targets
+        {after_target_args?}             (string[])                (optional) args appended after the resolved target, e.g. for flags to pass through to the target itself via `--`
+        {env?}                       (table<string,string>)    (optional) environment variables for generated tasks
+        {metadata?}                  (table)                   (optional) arbitrary metadata for generated tasks
+        {components?}                (overseer.Serialized[])   (optional) overseer components for generated tasks
+        {template_file_definition?}  (table)                   (optional) overrides values in the base overseer.TemplateFileDefinition
 
     See: ~
         |overseer.wrap_template|

--- a/lua/obazel/config/init.lua
+++ b/lua/obazel/config/init.lua
@@ -73,6 +73,7 @@
 ---@field args? string[] (optional) the args that will be passed to bazel; omit for none, e.g. `binary target`
 ---@field after_target_args? string[] (optional) args appended after `args`, e.g. for flags to pass through to the target itself via `--`
 ---@field binary? string (optional) override the configured `bazel_binary` for this template
+---@field cwd? string|fun(workspace_root: string): string (optional) task working directory, or a function of the resolved bazel workspace root that returns one; defaults to the workspace root
 ---@field env? table<string, string> (optional) environment variables for the task
 ---@field metadata? table (optional) arbitrary metadata for the task
 ---@field components? overseer.Serialized[] (optional) overseer components for the task
@@ -99,6 +100,7 @@
 ---@field args? string[] (optional) args that will be passed to bazel before the targets; omit for none, e.g. `binary target`
 ---@field after_target_args? string[] (optional) args appended after the resolved target, e.g. for flags to pass through to the target itself via `--`
 ---@field binary? string (optional) override the configured `bazel_binary` for generated tasks
+---@field cwd? string|fun(workspace_root: string): string (optional) task working directory, or a function of the resolved bazel workspace root that returns one; defaults to the workspace root
 ---@field env? table<string, string> (optional) environment variables for generated tasks
 ---@field metadata? table (optional) arbitrary metadata for generated tasks
 ---@field components? overseer.Serialized[] (optional) overseer components for generated tasks

--- a/lua/obazel/config/init.lua
+++ b/lua/obazel/config/init.lua
@@ -77,6 +77,7 @@
 ---@field env? table<string, string> (optional) environment variables for the task
 ---@field metadata? table (optional) arbitrary metadata for the task
 ---@field components? overseer.Serialized[] (optional) overseer components for the task
+---@field relative_file_root? string|fun(workspace_root: string): string (optional) root for resolving relative paths reported by output-parsing components (e.g. compiler diagnostics), or a function of the resolved bazel workspace root that returns one; defaults to the workspace root. Unlike overseer's own `relative_file_root` param, this does *not* fall back to task `cwd` when unset: bazel's own diagnostics are reported relative to the workspace root regardless of `cwd`, so obazel pins this independently rather than letting it silently track a `cwd` override.
 ---@field template overseer.TemplateDefinition the template definition
 
 ---A template generator using a bazel query.
@@ -104,6 +105,7 @@
 ---@field env? table<string, string> (optional) environment variables for generated tasks
 ---@field metadata? table (optional) arbitrary metadata for generated tasks
 ---@field components? overseer.Serialized[] (optional) overseer components for generated tasks
+---@field relative_file_root? string|fun(workspace_root: string): string (optional) root for resolving relative paths reported by output-parsing components (e.g. compiler diagnostics), or a function of the resolved bazel workspace root that returns one; defaults to the workspace root. Unlike overseer's own `relative_file_root` param, this does *not* fall back to task `cwd` when unset: bazel's own diagnostics are reported relative to the workspace root regardless of `cwd`, so obazel pins this independently rather than letting it silently track a `cwd` override.
 ---@field template_file_definition? table (optional) overrides values in the base overseer.TemplateFileDefinition
 ---@see overseer.TemplateFileDefinition
 

--- a/lua/obazel/config/init.lua
+++ b/lua/obazel/config/init.lua
@@ -70,8 +70,9 @@
 ---         template = { name = "bazel run //:gazelle" },
 ---     }
 ---@class obazel.TemplateConfig
----@field args string[] the args that will be passed to bazel
+---@field args? string[] (optional) the args that will be passed to bazel; omit for none, e.g. `binary target`
 ---@field after_target_args? string[] (optional) args appended after `args`, e.g. for flags to pass through to the target itself via `--`
+---@field binary? string (optional) override the configured `bazel_binary` for this template
 ---@field env? table<string, string> (optional) environment variables for the task
 ---@field metadata? table (optional) arbitrary metadata for the task
 ---@field components? overseer.Serialized[] (optional) overseer components for the task
@@ -95,8 +96,9 @@
 ---     }
 ---@class obazel.GeneratorConfig
 ---@field query_template string a query template where '%s' will be replaced by the target_prefix
----@field args string[] args that will be passed to bazel before the targets
+---@field args? string[] (optional) args that will be passed to bazel before the targets; omit for none, e.g. `binary target`
 ---@field after_target_args? string[] (optional) args appended after the resolved target, e.g. for flags to pass through to the target itself via `--`
+---@field binary? string (optional) override the configured `bazel_binary` for generated tasks
 ---@field env? table<string, string> (optional) environment variables for generated tasks
 ---@field metadata? table (optional) arbitrary metadata for generated tasks
 ---@field components? overseer.Serialized[] (optional) overseer components for generated tasks

--- a/lua/obazel/config/init.lua
+++ b/lua/obazel/config/init.lua
@@ -71,6 +71,10 @@
 ---     }
 ---@class obazel.TemplateConfig
 ---@field args string[] the args that will be passed to bazel
+---@field after_target_args? string[] (optional) args appended after `args`, e.g. for flags to pass through to the target itself via `--`
+---@field env? table<string, string> (optional) environment variables for the task
+---@field metadata? table (optional) arbitrary metadata for the task
+---@field components? overseer.Serialized[] (optional) overseer components for the task
 ---@field template overseer.TemplateDefinition the template definition
 
 ---A template generator using a bazel query.
@@ -92,6 +96,10 @@
 ---@class obazel.GeneratorConfig
 ---@field query_template string a query template where '%s' will be replaced by the target_prefix
 ---@field args string[] args that will be passed to bazel before the targets
+---@field after_target_args? string[] (optional) args appended after the resolved target, e.g. for flags to pass through to the target itself via `--`
+---@field env? table<string, string> (optional) environment variables for generated tasks
+---@field metadata? table (optional) arbitrary metadata for generated tasks
+---@field components? overseer.Serialized[] (optional) overseer components for generated tasks
 ---@field template_file_definition? table (optional) overrides values in the base overseer.TemplateFileDefinition
 ---@see overseer.TemplateFileDefinition
 

--- a/lua/obazel/config/init.lua
+++ b/lua/obazel/config/init.lua
@@ -11,8 +11,7 @@
 ---Example configuration
 --->lua
 ---     ---@module 'obazel'
----     ---@type obazel.Config
----     vim.g.obazel = {
+---     require("obazel").setup({
 ---       -- (optional) The binary used to invoke bazel commands
 ---       bazel_binary = "bazel",
 ---       overseer = {
@@ -48,7 +47,15 @@
 ---           },
 ---         },
 ---       },
----     }
+---     })
+---
+---Because |obazel.setup()| passes the config directly as a Lua table, values
+---like `template_file_definition` or `template` may contain overseer
+---components with configuration options, e.g.
+---`{ "on_output_parse", errorformat = "..." }`. This wasn't possible with the
+---old `vim.g.obazel`-based configuration, since values assigned to `vim.g`
+---variables are round-tripped through Vimscript, which has no way to
+---represent that shape of table.
 ---
 ---@brief ]]
 
@@ -108,9 +115,6 @@
 ---@field relative_file_root? string|fun(workspace_root: string): string (optional) root for resolving relative paths reported by output-parsing components (e.g. compiler diagnostics), or a function of the resolved bazel workspace root that returns one; defaults to the workspace root. Unlike overseer's own `relative_file_root` param, this does *not* fall back to task `cwd` when unset: bazel's own diagnostics are reported relative to the workspace root regardless of `cwd`, so obazel pins this independently rather than letting it silently track a `cwd` override.
 ---@field template_file_definition? table (optional) overrides values in the base overseer.TemplateFileDefinition
 ---@see overseer.TemplateFileDefinition
-
----@type obazel.Config | fun():obazel.Config | nil
-vim.g.obazel = vim.g.obazel
 
 local config = {}
 

--- a/lua/obazel/config/internal.lua
+++ b/lua/obazel/config/internal.lua
@@ -20,25 +20,35 @@ local default_config = {
     },
 }
 
-local user_config = type(vim.g.obazel) == "function" and vim.g.obazel() or vim.g.obazel or {}
-
+---This table is returned by `require("obazel.config.internal")` and is
+---mutated in place by `config.setup()`, rather than replaced, so that
+---modules which grabbed a reference to it before `setup()` was called still
+---observe the final values.
 ---@type obazel.InternalConfig
-local config = vim.tbl_deep_extend("force", default_config, user_config, {
-    debug_info = {
-        unrecognized_configs = check.get_unrecognized_keys(user_config, default_config),
-    },
-})
+local config = vim.deepcopy(default_config)
 
-if #config.debug_info.unrecognized_configs > 0 then
-    vim.notify(
-        "unrecognized configs found in vim.g.obazel: " .. vim.inspect(config.debug_info.unrecognized_configs),
-        vim.log.levels.ERROR
-    )
-end
+---@param user_config? obazel.Config
+function config.setup(user_config)
+    user_config = user_config or {}
 
-local ok, err = check.validate(config)
-if not ok then
-    vim.notify("obazel: " .. err, vim.log.levels.ERROR)
+    local unrecognized_configs = check.get_unrecognized_keys(user_config, default_config)
+    local merged = vim.tbl_deep_extend("force", default_config, user_config)
+
+    config.bazel_binary = merged.bazel_binary
+    config.overseer = merged.overseer
+    config.debug_info = { unrecognized_configs = unrecognized_configs }
+
+    if #unrecognized_configs > 0 then
+        vim.notify(
+            "unrecognized configs passed to obazel.setup(): " .. vim.inspect(unrecognized_configs),
+            vim.log.levels.ERROR
+        )
+    end
+
+    local ok, err = check.validate(config)
+    if not ok then
+        vim.notify("obazel: " .. err, vim.log.levels.ERROR)
+    end
 end
 
 return config

--- a/lua/obazel/init.lua
+++ b/lua/obazel/init.lua
@@ -14,16 +14,18 @@
 ---current open file, for example `bazel run //:gazelle`, they can be
 ---configured as static templates.
 ---
----See |obazel-nvim.config| for an example configuration.
----
----The template provider will need to be registered with overseer:
+---Call |obazel.setup()| to configure obazel.nvim, then register the template
+---provider with overseer:
 --->lua
+---     require("obazel").setup({ ... })
 ---     require("overseer").setup({
 ---         templates = {
 ---             "builtin",
 ---             "obazel",
 ---         },
 ---     }
+---
+---See |obazel-nvim.config| for an example configuration.
 ---
 ---See:
 ---     https://github.com/stevearc/overseer.nvim/blob/master/doc/guides.md
@@ -33,5 +35,12 @@
 ---@toc obazel-contents
 
 local obazel = {}
+
+---Configure obazel.nvim. Must be called before overseer.nvim collects
+---templates (e.g. via |:OverseerRun| or `preload_task_cache()`).
+---@param opts? obazel.Config
+function obazel.setup(opts)
+    require("obazel.config.internal").setup(opts)
+end
 
 return obazel

--- a/lua/overseer/template/obazel/init.lua
+++ b/lua/overseer/template/obazel/init.lua
@@ -56,6 +56,7 @@ function provider.generator(opts, cb)
     for _, template_config in ipairs(config.overseer.templates) do
         local binary = template_config.binary or config.bazel_binary
         local cwd = resolve_workspace_relative(template_config.cwd, workspace_root)
+        local relative_file_root = resolve_workspace_relative(template_config.relative_file_root, workspace_root)
 
         table.insert(
             templates,
@@ -74,6 +75,7 @@ function provider.generator(opts, cb)
                     env = { type = "opaque", optional = true, default = template_config.env },
                     metadata = { type = "opaque", optional = true, default = template_config.metadata },
                     components = { type = "opaque", optional = true, default = template_config.components },
+                    relative_file_root = { type = "string", optional = true, default = relative_file_root },
                 },
                 builder = function(params)
                     vim.list_extend(params.args, params.after_target_args)
@@ -84,6 +86,12 @@ function provider.generator(opts, cb)
                         env = params.env,
                         metadata = params.metadata,
                         components = params.components,
+                        -- Picked up by any attached component whose param
+                        -- has `default_from_task = true`, e.g.
+                        -- `on_output_parse`'s `relative_file_root`, so
+                        -- relative diagnostic paths resolve against the
+                        -- bazel workspace root instead of task cwd.
+                        default_component_params = { relative_file_root = params.relative_file_root },
                     }
                 end,
             }, template_config.template)
@@ -106,6 +114,7 @@ function provider.generator(opts, cb)
         local args = query_config.args or {}
         local after_target_args = query_config.after_target_args or {}
         local cwd = resolve_workspace_relative(query_config.cwd, workspace_root)
+        local relative_file_root = resolve_workspace_relative(query_config.relative_file_root, workspace_root)
 
         bazel.query(query, function(targets, err2)
             if err2 ~= nil then
@@ -149,6 +158,11 @@ function provider.generator(opts, cb)
                                     default = query_config.components,
                                 },
                                 cwd = { type = "string", optional = true, default = cwd },
+                                relative_file_root = {
+                                    type = "string",
+                                    optional = true,
+                                    default = relative_file_root,
+                                },
                             },
                             builder = function(params)
                                 local qargs = vim.deepcopy(params.args)
@@ -161,6 +175,7 @@ function provider.generator(opts, cb)
                                     env = params.env,
                                     metadata = params.metadata,
                                     components = params.components,
+                                    default_component_params = { relative_file_root = params.relative_file_root },
                                 }
                             end,
                         }, query_config.template_file_definition or {})

--- a/lua/overseer/template/obazel/init.lua
+++ b/lua/overseer/template/obazel/init.lua
@@ -42,8 +42,18 @@ function provider.generator(opts, cb)
     ---@type overseer.TemplateDefinition[]
     local templates = {}
 
+    -- Used for the generated task name below, e.g. "/usr/bin/bazelisk" -> "bazelisk"
+    local binary_tail = vim.fn.fnamemodify(config.bazel_binary, ":t")
+
     for _, template_config in ipairs(config.overseer.templates) do
         local args = template_config.args
+        if template_config.after_target_args then
+            args = vim.list_extend(vim.deepcopy(args), template_config.after_target_args)
+        end
+        local env = template_config.env
+        local metadata = template_config.metadata
+        local components = template_config.components
+
         table.insert(
             templates,
             vim.tbl_deep_extend("force", {
@@ -51,6 +61,9 @@ function provider.generator(opts, cb)
                     return {
                         cmd = { config.bazel_binary },
                         args = args,
+                        env = env,
+                        metadata = metadata,
+                        components = components,
                     }
                 end,
             }, template_config.template)
@@ -76,15 +89,34 @@ function provider.generator(opts, cb)
                     -- TODO toggleable in config to show short or long targets?
                     local short_target = remove_prefix(target, target_prefix)
                     local qargs = vim.list_extend(vim.deepcopy(query_config.args), { target })
+                    if query_config.after_target_args then
+                        vim.list_extend(qargs, query_config.after_target_args)
+                    end
+                    local env = query_config.env
+                    local metadata = query_config.metadata
+                    local components = query_config.components
+
+                    -- Mirrors the order of `cmd`/`qargs` below (binary, base
+                    -- args, target, after_target_args), but with `short_target`
+                    -- in place of the fully-qualified target for readability.
+                    local name_parts = { binary_tail }
+                    vim.list_extend(name_parts, query_config.args)
+                    table.insert(name_parts, short_target)
+                    if query_config.after_target_args then
+                        vim.list_extend(name_parts, query_config.after_target_args)
+                    end
 
                     table.insert(
                         templates,
                         vim.tbl_deep_extend("force", {
-                            name = ("bazel %s %s"):format(table.concat(query_config.args, " "), short_target),
+                            name = table.concat(name_parts, " "),
                             builder = function()
                                 return {
                                     cmd = { config.bazel_binary },
                                     args = qargs,
+                                    env = env,
+                                    metadata = metadata,
+                                    components = components,
                                 }
                             end,
                         }, query_config.template_file_definition or {})

--- a/lua/overseer/template/obazel/init.lua
+++ b/lua/overseer/template/obazel/init.lua
@@ -19,6 +19,16 @@ local function remove_prefix(str, prefix)
     end
 end
 
+---@param value string|fun(workspace_root: string):string|nil
+---@param workspace_root string
+---@return string
+local function resolve_workspace_relative(value, workspace_root)
+    if type(value) == "function" then
+        return value(workspace_root)
+    end
+    return value or workspace_root
+end
+
 ---@type overseer.TemplateProvider
 local provider = {
     name = "bazel",
@@ -38,12 +48,14 @@ function provider.generator(opts, cb)
     if err1 ~= nil then
         return err1
     end
+    local workspace_root = bazel.resolve_workspace_dir(opts.dir)
 
     ---@type overseer.TemplateDefinition[]
     local templates = {}
 
     for _, template_config in ipairs(config.overseer.templates) do
         local binary = template_config.binary or config.bazel_binary
+        local cwd = resolve_workspace_relative(template_config.cwd, workspace_root)
 
         table.insert(
             templates,
@@ -58,6 +70,7 @@ function provider.generator(opts, cb)
                         optional = true,
                         default = template_config.after_target_args or {},
                     },
+                    cwd = { type = "string", optional = true, default = cwd },
                     env = { type = "opaque", optional = true, default = template_config.env },
                     metadata = { type = "opaque", optional = true, default = template_config.metadata },
                     components = { type = "opaque", optional = true, default = template_config.components },
@@ -67,6 +80,7 @@ function provider.generator(opts, cb)
                     return {
                         cmd = { params.binary },
                         args = params.args,
+                        cwd = params.cwd,
                         env = params.env,
                         metadata = params.metadata,
                         components = params.components,
@@ -91,6 +105,7 @@ function provider.generator(opts, cb)
         local binary_tail = vim.fn.fnamemodify(binary, ":t")
         local args = query_config.args or {}
         local after_target_args = query_config.after_target_args or {}
+        local cwd = resolve_workspace_relative(query_config.cwd, workspace_root)
 
         bazel.query(query, function(targets, err2)
             if err2 ~= nil then
@@ -133,6 +148,7 @@ function provider.generator(opts, cb)
                                     optional = true,
                                     default = query_config.components,
                                 },
+                                cwd = { type = "string", optional = true, default = cwd },
                             },
                             builder = function(params)
                                 local qargs = vim.deepcopy(params.args)
@@ -141,6 +157,7 @@ function provider.generator(opts, cb)
                                 return {
                                     cmd = { params.binary },
                                     args = qargs,
+                                    cwd = params.cwd,
                                     env = params.env,
                                     metadata = params.metadata,
                                     components = params.components,

--- a/lua/overseer/template/obazel/init.lua
+++ b/lua/overseer/template/obazel/init.lua
@@ -42,28 +42,34 @@ function provider.generator(opts, cb)
     ---@type overseer.TemplateDefinition[]
     local templates = {}
 
-    -- Used for the generated task name below, e.g. "/usr/bin/bazelisk" -> "bazelisk"
-    local binary_tail = vim.fn.fnamemodify(config.bazel_binary, ":t")
-
     for _, template_config in ipairs(config.overseer.templates) do
-        local args = template_config.args
-        if template_config.after_target_args then
-            args = vim.list_extend(vim.deepcopy(args), template_config.after_target_args)
-        end
-        local env = template_config.env
-        local metadata = template_config.metadata
-        local components = template_config.components
+        local binary = template_config.binary or config.bazel_binary
 
         table.insert(
             templates,
             vim.tbl_deep_extend("force", {
-                builder = function()
+                ---@type overseer.Params
+                params = {
+                    binary = { type = "string", optional = true, default = binary },
+                    args = { type = "list", delimiter = " ", optional = true, default = template_config.args or {} },
+                    after_target_args = {
+                        type = "list",
+                        delimiter = " ",
+                        optional = true,
+                        default = template_config.after_target_args or {},
+                    },
+                    env = { type = "opaque", optional = true, default = template_config.env },
+                    metadata = { type = "opaque", optional = true, default = template_config.metadata },
+                    components = { type = "opaque", optional = true, default = template_config.components },
+                },
+                builder = function(params)
+                    vim.list_extend(params.args, params.after_target_args)
                     return {
-                        cmd = { config.bazel_binary },
-                        args = args,
-                        env = env,
-                        metadata = metadata,
-                        components = components,
+                        cmd = { params.binary },
+                        args = params.args,
+                        env = params.env,
+                        metadata = params.metadata,
+                        components = params.components,
                     }
                 end,
             }, template_config.template)
@@ -80,6 +86,11 @@ function provider.generator(opts, cb)
 
     for _, query_config in ipairs(generators) do
         local query = query_config.query_template:format(target_prefix)
+        local binary = query_config.binary or config.bazel_binary
+        -- Used for the generated task name below, e.g. "/usr/bin/bazelisk" -> "bazelisk"
+        local binary_tail = vim.fn.fnamemodify(binary, ":t")
+        local args = query_config.args or {}
+        local after_target_args = query_config.after_target_args or {}
 
         bazel.query(query, function(targets, err2)
             if err2 ~= nil then
@@ -88,35 +99,51 @@ function provider.generator(opts, cb)
                 for _, target in ipairs(targets) do
                     -- TODO toggleable in config to show short or long targets?
                     local short_target = remove_prefix(target, target_prefix)
-                    local qargs = vim.list_extend(vim.deepcopy(query_config.args), { target })
-                    if query_config.after_target_args then
-                        vim.list_extend(qargs, query_config.after_target_args)
-                    end
-                    local env = query_config.env
-                    local metadata = query_config.metadata
-                    local components = query_config.components
 
-                    -- Mirrors the order of `cmd`/`qargs` below (binary, base
-                    -- args, target, after_target_args), but with `short_target`
-                    -- in place of the fully-qualified target for readability.
+                    -- Mirrors the order of the args built in `builder` below
+                    -- (binary, base args, target, after_target_args), but with
+                    -- `short_target` in place of the fully-qualified target
+                    -- for readability. `args`/`after_target_args` default to
+                    -- {}, so an entry with neither set produces just
+                    -- "binary target", e.g. "foo //blah/blah:target".
                     local name_parts = { binary_tail }
-                    vim.list_extend(name_parts, query_config.args)
+                    vim.list_extend(name_parts, args)
                     table.insert(name_parts, short_target)
-                    if query_config.after_target_args then
-                        vim.list_extend(name_parts, query_config.after_target_args)
-                    end
+                    vim.list_extend(name_parts, after_target_args)
 
                     table.insert(
                         templates,
                         vim.tbl_deep_extend("force", {
                             name = table.concat(name_parts, " "),
-                            builder = function()
+                            ---@type overseer.Params
+                            params = {
+                                binary = { type = "string", optional = true, default = binary },
+                                args = { type = "list", delimiter = " ", optional = true, default = args },
+                                target = { type = "string", optional = true, default = target },
+                                after_target_args = {
+                                    type = "list",
+                                    delimiter = " ",
+                                    optional = true,
+                                    default = after_target_args,
+                                },
+                                env = { type = "opaque", optional = true, default = query_config.env },
+                                metadata = { type = "opaque", optional = true, default = query_config.metadata },
+                                components = {
+                                    type = "opaque",
+                                    optional = true,
+                                    default = query_config.components,
+                                },
+                            },
+                            builder = function(params)
+                                local qargs = vim.deepcopy(params.args)
+                                table.insert(qargs, params.target)
+                                vim.list_extend(qargs, params.after_target_args)
                                 return {
-                                    cmd = { config.bazel_binary },
+                                    cmd = { params.binary },
                                     args = qargs,
-                                    env = env,
-                                    metadata = metadata,
-                                    components = components,
+                                    env = params.env,
+                                    metadata = params.metadata,
+                                    components = params.components,
                                 }
                             end,
                         }, query_config.template_file_definition or {})

--- a/lua/overseer/template/obazel/init.lua
+++ b/lua/overseer/template/obazel/init.lua
@@ -7,9 +7,8 @@
 ---@brief ]]
 
 local bazel = require("obazel.bazel")
+local check = require("obazel.config.check")
 local config = require("obazel.config.internal")
-
-local config_is_valid = require("obazel.config.check").validate(config)
 
 local function remove_prefix(str, prefix)
     if str:sub(1, #prefix) == prefix then
@@ -40,6 +39,7 @@ function provider.cache_key(opts)
 end
 
 function provider.generator(opts, cb)
+    local config_is_valid = check.validate(config)
     if not config_is_valid then
         return "Invalid obazel config"
     end


### PR DESCRIPTION
BREAKING CHANGE: vim.g.obazel is no longer read. Configure obazel.nvim by calling require("obazel").setup({...}) instead, before overseer.nvim collects templates.

Unclear if this change is actually desirable as I've realized it isn't strictly necessary for the functionality I was looking for, but leaving it open for now.