### PR TITLE
feat: support after_target_args/env/metadata/components in template config

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,15 @@ vim.g.obazel = {
           tags = { "BUILD" },
         },
       },
+      {
+        -- `args` is optional; omitting it produces just "binary target",
+        -- e.g. for a custom wrapper script that takes a target directly.
+        query_template = "kind(rule, %s:*)",
+        binary = "foo",
+        template_file_definition = {
+          tags = { "FOO" },
+        },
+      },
     },
   },
 }
@@ -146,17 +155,45 @@ string keys), never both. Overseer components like
 so a `templates`/`generators` entry that carries nontrivial components
 can only be expressed this way.
 
-Each entry in `templates`/`generators` also accepts `after_target_args`, `env`,
-`metadata`, and `components`, which are merged into the
+Each entry in `templates`/`generators` also accepts `args`, `after_target_args`,
+`binary`, `env`, `metadata`, and `components`, which are merged into the
 `overseer.TaskDefinition` produced for that template/generated task (see
 `obazel.TemplateConfig` and `obazel.GeneratorConfig`). These are distinct
 from `template`/`template_file_definition`, which only affect the
 `overseer.TemplateDefinition` shown in `:OverseerRun`; fields like
 `components`, `env`, and `metadata` have no effect there, since they belong
-to the task, not the template.
+to the task, not the template. `args` and `binary` are both optional:
+omitting `args` produces a command with none (just `binary target` for
+generators), and omitting `binary` falls back to the top-level
+`bazel_binary`.
 
 The name of a generated task (from `generators`, not `templates`) starts
-with the tail of `config.bazel_binary` (e.g. `/usr/bin/bazelisk` becomes
-`bazelisk`), followed by `args`, the resolved target, and `after_target_args`,
-so task names stay accurate and distinct even when `bazel_binary` or
+with the tail of `binary` (its own `binary` if set, otherwise the tail of
+`config.bazel_binary`, e.g. `/usr/bin/bazelisk` becomes `bazelisk`),
+followed by `args`, the resolved target, and `after_target_args`, so task
+names stay accurate and distinct even when `binary`, `args`, or
 `after_target_args` differ between generator entries.
+
+Because `template`/`template_file_definition` are plain
+`overseer.TemplateDefinition`/`overseer.TemplateFileDefinition` tables, you
+can also supply your own `builder` there to fully replace obazel's. Doing so
+still gives you access to everything obazel would otherwise have used to
+build the task: `binary`, `args`, `after_target_args`, `env`, `metadata`,
+`components`, and (for `generators` only) the resolved `target`, via the
+`params` argument overseer passes to `builder(params)`:
+
+```lua
+{
+  query_template = "tests(%s:*)",
+  args = { "test" },
+  template_file_definition = {
+    builder = function(params)
+      return {
+        cmd = { params.binary },
+        args = { "test", params.target, "--test_output=all" },
+        env = params.env,
+      }
+    end,
+  },
+}
+```

--- a/README.md
+++ b/README.md
@@ -112,3 +112,25 @@ vim.g.obazel = {
   },
 }
 ```
+
+`vim.g.obazel` may also be set to a function that returns the config
+table, called lazily whenever obazel reads its configuration:
+
+```lua
+vim.g.obazel = function()
+  return {
+    overseer = {
+      templates = { ... },
+    },
+  }
+end
+```
+
+Only the function itself is stored in `vim.g.obazel`; its return value
+never passes through `vim.g`'s own value conversion. This matters because
+`vim.g` variables are round-tripped through Vimscript, which requires
+every table to be either a list (only integer keys) or a dict (only
+string keys), never both. Overseer components like
+`{ "on_output_parse", errorformat = "..." }` mix both in a single table,
+so a `templates`/`generators` entry that carries nontrivial components
+can only be expressed this way.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,17 @@ vim.g.obazel = {
         args = { "run", "//:gazelle" },
         template = { name = "bazel run //:gazelle" },
       },
+      {
+        args = { "test", "//..." },
+        -- Appended after the target (unlike `args`, which comes before it),
+        -- e.g. for flags you want passed through to the test binary itself
+        -- via `--`.
+        after_target_args = { "--", "--some-flag" },
+        env = { BAZEL_CONFIG = "ci" },
+        metadata = { kind = "test" },
+        components = { "default", { "on_output_parse", errorformat = "..." } },
+        template = { name = "bazel test //..." },
+      },
     },
     -- Task templates generated via bazel queries. The '%s' sign in the
     -- query_template will be replaced with the target_prefix, which is the
@@ -134,3 +145,18 @@ string keys), never both. Overseer components like
 `{ "on_output_parse", errorformat = "..." }` mix both in a single table,
 so a `templates`/`generators` entry that carries nontrivial components
 can only be expressed this way.
+
+Each entry in `templates`/`generators` also accepts `after_target_args`, `env`,
+`metadata`, and `components`, which are merged into the
+`overseer.TaskDefinition` produced for that template/generated task (see
+`obazel.TemplateConfig` and `obazel.GeneratorConfig`). These are distinct
+from `template`/`template_file_definition`, which only affect the
+`overseer.TemplateDefinition` shown in `:OverseerRun`; fields like
+`components`, `env`, and `metadata` have no effect there, since they belong
+to the task, not the template.
+
+The name of a generated task (from `generators`, not `templates`) starts
+with the tail of `config.bazel_binary` (e.g. `/usr/bin/bazelisk` becomes
+`bazelisk`), followed by `args`, the resolved target, and `after_target_args`,
+so task names stay accurate and distinct even when `bazel_binary` or
+`after_target_args` differ between generator entries.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ vim.g.obazel = {
     templates = {
       {
         args = { "run", "//:gazelle" },
-        template = { name = "bazel run //:gazelle", priority = 50 },
+        template = { name = "bazel run //:gazelle" },
       },
     },
     -- Task templates generated via bazel queries. The '%s' sign in the
@@ -92,7 +92,6 @@ vim.g.obazel = {
         args = { "test" },
         template_file_definition = {
           tags = { "TEST" },
-          priority = 51,
         },
       },
       {
@@ -100,7 +99,6 @@ vim.g.obazel = {
         args = { "run" },
         template_file_definition = {
           tags = { "RUN" },
-          priority = 52,
         },
       },
       {
@@ -108,7 +106,6 @@ vim.g.obazel = {
         args = { "build" },
         template_file_definition = {
           tags = { "BUILD" },
-          priority = 100,
         },
       },
     },

--- a/doc/obazel.nvim.txt
+++ b/doc/obazel.nvim.txt
@@ -26,7 +26,6 @@ The template provider will need to be registered with overseer:
      }
 
 See:
-     |overseer.wrap_template|
      https://github.com/stevearc/overseer.nvim/blob/master/doc/guides.md
 
 ==============================================================================
@@ -56,7 +55,7 @@ Example configuration
          templates = {
            {
              args = { "run", "//:gazelle" },
-             template = { name = "bazel run //:gazelle", priority = 50 },
+             template = { name = "bazel run //:gazelle" },
            },
          },
          -- task templates generated via bazel queries
@@ -66,7 +65,6 @@ Example configuration
              args = { "test" },
              template_file_definition = {
                tags = { "TEST" },
-               priority = 51,
              },
            },
            {
@@ -74,7 +72,6 @@ Example configuration
              args = { "run" },
              template_file_definition = {
                tags = { "RUN" },
-               priority = 52,
              },
            },
            {
@@ -82,7 +79,6 @@ Example configuration
              args = { "build" },
              template_file_definition = {
                tags = { "BUILD" },
-               priority = 100,
              },
            },
          },
@@ -108,11 +104,11 @@ obazel.TemplateConfig                                    *obazel.TemplateConfig*
     A static template definition for bazel targets that you always want to have
     available. For example `bazel run //:gazelle`.
 
-    Use the `template` argument to set the `name` and `priority` of the task:
+    Use the `template` argument to set the `name` of the task:
     >lua
          {
              args = { "run", "//:gazelle" },
-             template = { name = "bazel run //:gazelle", priority = 50 },
+             template = { name = "bazel run //:gazelle" },
          }
 
     Fields: ~
@@ -135,7 +131,6 @@ obazel.GeneratorConfig                                  *obazel.GeneratorConfig*
            args = { "test" },
            template_file_definition = {
              tags = { "TEST" },
-             priority = 51,
            },
          }
 
@@ -145,7 +140,7 @@ obazel.GeneratorConfig                                  *obazel.GeneratorConfig*
         {template_file_definition?}  (table)     (optional) overrides values in the base overseer.TemplateFileDefinition
 
     See: ~
-        |overseer.wrap_template|
+        |overseer.TemplateFileDefinition|
 
 
 ==============================================================================
@@ -158,6 +153,8 @@ Utilities for working with Bazel workspaces
                                       *obazel-nvim.bazel.resolve_workspace_file*
 bazel.resolve_workspace_file({directory})
     Resolves the WORKSPACE file path
+    Recognises MODULE.bazel, REPO.bazel (Bzlmod), WORKSPACE.bazel, and WORKSPACE
+    as workspace root markers, checked in that order of preference.
 
     Parameters: ~
         {directory}  (nil|string)  (default: vim.fn.getcwd())
@@ -178,7 +175,8 @@ bazel.resolve_workspace_dir({directory})
 
 
 bazel.resolve_buildfile({directory})       *obazel-nvim.bazel.resolve_buildfile*
-    Resolves the nearest BUILD.bazel file from the given directory
+    Resolves the nearest BUILD or BUILD.bazel file from the given directory
+    Prefers BUILD.bazel if both exist in the same directory
 
     Parameters: ~
         {directory}  (string)
@@ -205,19 +203,16 @@ bazel.resolve_target_prefix({directory})
         (nil|string)  error_message
 
 
-bazel.query({query})                                   *obazel-nvim.bazel.query*
-    Run a bazel query
+bazel.query({query}, {callback})                       *obazel-nvim.bazel.query*
+    Run a bazel query asynchronously
 
     Parameters: ~
-        {query}  (string)
-
-    Returns: ~
-        (string[])    targets
-        (nil|string)  error_message
+        {query}     (string)
+        {callback}  (fun(targets:string[],error_message:string|nil))
 
     Usage: ~
 >lua
-        bazel.query("//foo/bar/...")
+        bazel.query("//foo/bar/...", function(targets, err) ... end)
 <
 
 

--- a/doc/obazel.nvim.txt
+++ b/doc/obazel.nvim.txt
@@ -132,8 +132,12 @@ obazel.TemplateConfig                                    *obazel.TemplateConfig*
          }
 
     Fields: ~
-        {args}      (string[])                     the args that will be passed to bazel
-        {template}  (overseer.TemplateDefinition)  the template definition
+        {args}                (string[])                     the args that will be passed to bazel
+        {after_target_args?}  (string[])                     (optional) args appended after `args`, e.g. for flags to pass through to the target itself via `--`
+        {env?}                (table<string,string>)         (optional) environment variables for the task
+        {metadata?}           (table)                        (optional) arbitrary metadata for the task
+        {components?}         (overseer.Serialized[])        (optional) overseer components for the task
+        {template}            (overseer.TemplateDefinition)  the template definition
 
 
 obazel.GeneratorConfig                                  *obazel.GeneratorConfig*
@@ -155,9 +159,13 @@ obazel.GeneratorConfig                                  *obazel.GeneratorConfig*
          }
 
     Fields: ~
-        {query_template}             (string)    a query template where '%s' will be replaced by the target_prefix
-        {args}                       (string[])  args that will be passed to bazel before the targets
-        {template_file_definition?}  (table)     (optional) overrides values in the base overseer.TemplateFileDefinition
+        {query_template}             (string)                 a query template where '%s' will be replaced by the target_prefix
+        {args}                       (string[])               args that will be passed to bazel before the targets
+        {after_target_args?}         (string[])               (optional) args appended after the resolved target, e.g. for flags to pass through to the target itself via `--`
+        {env?}                       (table<string,string>)   (optional) environment variables for generated tasks
+        {metadata?}                  (table)                  (optional) arbitrary metadata for generated tasks
+        {components?}                (overseer.Serialized[])  (optional) overseer components for generated tasks
+        {template_file_definition?}  (table)                  (optional) overrides values in the base overseer.TemplateFileDefinition
 
     See: ~
         |overseer.TemplateFileDefinition|

--- a/doc/obazel.nvim.txt
+++ b/doc/obazel.nvim.txt
@@ -132,8 +132,9 @@ obazel.TemplateConfig                                    *obazel.TemplateConfig*
          }
 
     Fields: ~
-        {args}                (string[])                     the args that will be passed to bazel
+        {args?}               (string[])                     (optional) the args that will be passed to bazel; omit for none, e.g. `binary target`
         {after_target_args?}  (string[])                     (optional) args appended after `args`, e.g. for flags to pass through to the target itself via `--`
+        {binary?}             (string)                       (optional) override the configured `bazel_binary` for this template
         {env?}                (table<string,string>)         (optional) environment variables for the task
         {metadata?}           (table)                        (optional) arbitrary metadata for the task
         {components?}         (overseer.Serialized[])        (optional) overseer components for the task
@@ -160,8 +161,9 @@ obazel.GeneratorConfig                                  *obazel.GeneratorConfig*
 
     Fields: ~
         {query_template}             (string)                 a query template where '%s' will be replaced by the target_prefix
-        {args}                       (string[])               args that will be passed to bazel before the targets
+        {args?}                      (string[])               (optional) args that will be passed to bazel before the targets; omit for none, e.g. `binary target`
         {after_target_args?}         (string[])               (optional) args appended after the resolved target, e.g. for flags to pass through to the target itself via `--`
+        {binary?}                    (string)                 (optional) override the configured `bazel_binary` for generated tasks
         {env?}                       (table<string,string>)   (optional) environment variables for generated tasks
         {metadata?}                  (table)                  (optional) arbitrary metadata for generated tasks
         {components?}                (overseer.Serialized[])  (optional) overseer components for generated tasks

--- a/doc/obazel.nvim.txt
+++ b/doc/obazel.nvim.txt
@@ -85,6 +85,26 @@ Example configuration
        },
      }
 
+`vim.g.obazel` may also be set to a function that returns the config
+table, called lazily whenever obazel reads its configuration:
+>lua
+     vim.g.obazel = function()
+       return {
+         overseer = {
+           templates = { ... },
+         },
+       }
+     end
+
+Only the function itself is stored in `vim.g.obazel`; its return value
+never passes through `vim.g`'s own value conversion. This matters
+because `vim.g` variables are round-tripped through Vimscript, which
+requires every table to be either a list (only integer keys) or a dict
+(only string keys), never both. Overseer components like
+`{ "on_output_parse", errorformat = "..." }` mix both in a single
+table, so a `templates`/`generators` entry that carries nontrivial
+components can only be expressed this way.
+
 
 obazel.Config                                                    *obazel.Config*
 

--- a/lua/obazel/config/init.lua
+++ b/lua/obazel/config/init.lua
@@ -91,6 +91,10 @@
 ---     }
 ---@class obazel.TemplateConfig
 ---@field args string[] the args that will be passed to bazel
+---@field after_target_args? string[] (optional) args appended after `args`, e.g. for flags to pass through to the target itself via `--`
+---@field env? table<string, string> (optional) environment variables for the task
+---@field metadata? table (optional) arbitrary metadata for the task
+---@field components? overseer.Serialized[] (optional) overseer components for the task
 ---@field template overseer.TemplateDefinition the template definition
 
 ---A template generator using a bazel query.
@@ -112,6 +116,10 @@
 ---@class obazel.GeneratorConfig
 ---@field query_template string a query template where '%s' will be replaced by the target_prefix
 ---@field args string[] args that will be passed to bazel before the targets
+---@field after_target_args? string[] (optional) args appended after the resolved target, e.g. for flags to pass through to the target itself via `--`
+---@field env? table<string, string> (optional) environment variables for generated tasks
+---@field metadata? table (optional) arbitrary metadata for generated tasks
+---@field components? overseer.Serialized[] (optional) overseer components for generated tasks
 ---@field template_file_definition? table (optional) overrides values in the base overseer.TemplateFileDefinition
 ---@see overseer.TemplateFileDefinition
 

--- a/lua/obazel/config/init.lua
+++ b/lua/obazel/config/init.lua
@@ -50,6 +50,26 @@
 ---       },
 ---     }
 ---
+---`vim.g.obazel` may also be set to a function that returns the config
+---table, called lazily whenever obazel reads its configuration:
+--->lua
+---     vim.g.obazel = function()
+---       return {
+---         overseer = {
+---           templates = { ... },
+---         },
+---       }
+---     end
+---
+---Only the function itself is stored in `vim.g.obazel`; its return value
+---never passes through `vim.g`'s own value conversion. This matters
+---because `vim.g` variables are round-tripped through Vimscript, which
+---requires every table to be either a list (only integer keys) or a dict
+---(only string keys), never both. Overseer components like
+---`{ "on_output_parse", errorformat = "..." }` mix both in a single
+---table, so a `templates`/`generators` entry that carries nontrivial
+---components can only be expressed this way.
+---
 ---@brief ]]
 
 ---@class obazel.Config

--- a/lua/obazel/config/init.lua
+++ b/lua/obazel/config/init.lua
@@ -90,8 +90,9 @@
 ---         template = { name = "bazel run //:gazelle" },
 ---     }
 ---@class obazel.TemplateConfig
----@field args string[] the args that will be passed to bazel
+---@field args? string[] (optional) the args that will be passed to bazel; omit for none, e.g. `binary target`
 ---@field after_target_args? string[] (optional) args appended after `args`, e.g. for flags to pass through to the target itself via `--`
+---@field binary? string (optional) override the configured `bazel_binary` for this template
 ---@field env? table<string, string> (optional) environment variables for the task
 ---@field metadata? table (optional) arbitrary metadata for the task
 ---@field components? overseer.Serialized[] (optional) overseer components for the task
@@ -115,8 +116,9 @@
 ---     }
 ---@class obazel.GeneratorConfig
 ---@field query_template string a query template where '%s' will be replaced by the target_prefix
----@field args string[] args that will be passed to bazel before the targets
+---@field args? string[] (optional) args that will be passed to bazel before the targets; omit for none, e.g. `binary target`
 ---@field after_target_args? string[] (optional) args appended after the resolved target, e.g. for flags to pass through to the target itself via `--`
+---@field binary? string (optional) override the configured `bazel_binary` for generated tasks
 ---@field env? table<string, string> (optional) environment variables for generated tasks
 ---@field metadata? table (optional) arbitrary metadata for generated tasks
 ---@field components? overseer.Serialized[] (optional) overseer components for generated tasks

--- a/lua/overseer/template/obazel/init.lua
+++ b/lua/overseer/template/obazel/init.lua
@@ -42,26 +42,32 @@ function provider.generator(opts, cb)
     ---@type overseer.TemplateDefinition[]
     local templates = {}
 
-    -- Used for the generated task name below, e.g. "/usr/bin/bazelisk" -> "bazelisk"
-    local binary_tail = vim.fn.fnamemodify(config.bazel_binary, ":t")
-
     for _, template_config in ipairs(config.overseer.templates) do
-        local args = template_config.args
-        if template_config.after_target_args then
-            args = vim.list_extend(vim.deepcopy(args), template_config.after_target_args)
-        end
-        local env = template_config.env
+        local binary = template_config.binary or config.bazel_binary
         local metadata = template_config.metadata
         local components = template_config.components
 
         table.insert(
             templates,
             vim.tbl_deep_extend("force", {
-                builder = function()
+                ---@type overseer.Params
+                params = {
+                    binary = { type = "string", optional = true, default = binary },
+                    args = { type = "list", delimiter = " ", optional = true, default = template_config.args or {} },
+                    after_target_args = {
+                        type = "list",
+                        delimiter = " ",
+                        optional = true,
+                        default = template_config.after_target_args or {},
+                    },
+                    env = { type = "opaque", optional = true, default = template_config.env },
+                },
+                builder = function(params)
+                    vim.list_extend(params.args, params.after_target_args)
                     return {
-                        cmd = { config.bazel_binary },
-                        args = args,
-                        env = env,
+                        cmd = { params.binary },
+                        args = params.args,
+                        env = params.env,
                         metadata = metadata,
                         components = components,
                     }
@@ -80,6 +86,13 @@ function provider.generator(opts, cb)
 
     for _, query_config in ipairs(generators) do
         local query = query_config.query_template:format(target_prefix)
+        local binary = query_config.binary or config.bazel_binary
+        -- Used for the generated task name below, e.g. "/usr/bin/bazelisk" -> "bazelisk"
+        local binary_tail = vim.fn.fnamemodify(binary, ":t")
+        local args = query_config.args or {}
+        local after_target_args = query_config.after_target_args or {}
+        local metadata = query_config.metadata
+        local components = query_config.components
 
         bazel.query(query, function(targets, err2)
             if err2 ~= nil then
@@ -88,33 +101,43 @@ function provider.generator(opts, cb)
                 for _, target in ipairs(targets) do
                     -- TODO toggleable in config to show short or long targets?
                     local short_target = remove_prefix(target, target_prefix)
-                    local qargs = vim.list_extend(vim.deepcopy(query_config.args), { target })
-                    if query_config.after_target_args then
-                        vim.list_extend(qargs, query_config.after_target_args)
-                    end
-                    local env = query_config.env
-                    local metadata = query_config.metadata
-                    local components = query_config.components
 
-                    -- Mirrors the order of `cmd`/`qargs` below (binary, base
-                    -- args, target, after_target_args), but with `short_target`
-                    -- in place of the fully-qualified target for readability.
+                    -- Mirrors the order of the args built in `builder` below
+                    -- (binary, base args, target, after_target_args), but with
+                    -- `short_target` in place of the fully-qualified target
+                    -- for readability. `args`/`after_target_args` default to
+                    -- {}, so an entry with neither set produces just
+                    -- "binary target", e.g. "foo //blah/blah:target".
                     local name_parts = { binary_tail }
-                    vim.list_extend(name_parts, query_config.args)
+                    vim.list_extend(name_parts, args)
                     table.insert(name_parts, short_target)
-                    if query_config.after_target_args then
-                        vim.list_extend(name_parts, query_config.after_target_args)
-                    end
+                    vim.list_extend(name_parts, after_target_args)
 
                     table.insert(
                         templates,
                         vim.tbl_deep_extend("force", {
                             name = table.concat(name_parts, " "),
-                            builder = function()
+                            ---@type overseer.Params
+                            params = {
+                                binary = { type = "string", optional = true, default = binary },
+                                args = { type = "list", delimiter = " ", optional = true, default = args },
+                                target = { type = "string", optional = true, default = target },
+                                after_target_args = {
+                                    type = "list",
+                                    delimiter = " ",
+                                    optional = true,
+                                    default = after_target_args,
+                                },
+                                env = { type = "opaque", optional = true, default = query_config.env },
+                            },
+                            builder = function(params)
+                                local qargs = vim.deepcopy(params.args)
+                                table.insert(qargs, params.target)
+                                vim.list_extend(qargs, params.after_target_args)
                                 return {
-                                    cmd = { config.bazel_binary },
+                                    cmd = { params.binary },
                                     args = qargs,
-                                    env = env,
+                                    env = params.env,
                                     metadata = metadata,
                                     components = components,
                                 }

--- a/lua/overseer/template/obazel/init.lua
+++ b/lua/overseer/template/obazel/init.lua
@@ -42,8 +42,18 @@ function provider.generator(opts, cb)
     ---@type overseer.TemplateDefinition[]
     local templates = {}
 
+    -- Used for the generated task name below, e.g. "/usr/bin/bazelisk" -> "bazelisk"
+    local binary_tail = vim.fn.fnamemodify(config.bazel_binary, ":t")
+
     for _, template_config in ipairs(config.overseer.templates) do
         local args = template_config.args
+        if template_config.after_target_args then
+            args = vim.list_extend(vim.deepcopy(args), template_config.after_target_args)
+        end
+        local env = template_config.env
+        local metadata = template_config.metadata
+        local components = template_config.components
+
         table.insert(
             templates,
             vim.tbl_deep_extend("force", {
@@ -51,6 +61,9 @@ function provider.generator(opts, cb)
                     return {
                         cmd = { config.bazel_binary },
                         args = args,
+                        env = env,
+                        metadata = metadata,
+                        components = components,
                     }
                 end,
             }, template_config.template)
@@ -76,15 +89,34 @@ function provider.generator(opts, cb)
                     -- TODO toggleable in config to show short or long targets?
                     local short_target = remove_prefix(target, target_prefix)
                     local qargs = vim.list_extend(vim.deepcopy(query_config.args), { target })
+                    if query_config.after_target_args then
+                        vim.list_extend(qargs, query_config.after_target_args)
+                    end
+                    local env = query_config.env
+                    local metadata = query_config.metadata
+                    local components = query_config.components
+
+                    -- Mirrors the order of `cmd`/`qargs` below (binary, base
+                    -- args, target, after_target_args), but with `short_target`
+                    -- in place of the fully-qualified target for readability.
+                    local name_parts = { binary_tail }
+                    vim.list_extend(name_parts, query_config.args)
+                    table.insert(name_parts, short_target)
+                    if query_config.after_target_args then
+                        vim.list_extend(name_parts, query_config.after_target_args)
+                    end
 
                     table.insert(
                         templates,
                         vim.tbl_deep_extend("force", {
-                            name = ("bazel %s %s"):format(table.concat(query_config.args, " "), short_target),
+                            name = table.concat(name_parts, " "),
                             builder = function()
                                 return {
                                     cmd = { config.bazel_binary },
                                     args = qargs,
+                                    env = env,
+                                    metadata = metadata,
+                                    components = components,
                                 }
                             end,
                         }, query_config.template_file_definition or {})


### PR DESCRIPTION
Entries under `overseer.templates`/`overseer.generators` can now declare
`after_target_args`, `env`, `metadata`, and `components`, which are merged into
the `overseer.TaskDefinition` returned by that entry's builder. Previously
these had no effect when placed on `template`/`template_file_definition`,
since those only affect the `overseer.TemplateDefinition`, not the task.

Generated task names (from `generators`) now derive from the tail of
`config.bazel_binary` plus `after_target_args`, instead of a hardcoded "bazel"
prefix, so they stay accurate and stay distinct across generator entries
that only differ by those fields.

Fixes #6. Depends on #21.