### PR TITLE
Support overriding task cwd and `relative_file_root`

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,15 @@ vim.g.obazel = {
           tags = { "BUILD" },
         },
       },
+      {
+        -- `args` is optional; omitting it produces just "binary target",
+        -- e.g. for a custom wrapper script that takes a target directly.
+        query_template = "kind(rule, %s:*)",
+        binary = "foo",
+        template_file_definition = {
+          tags = { "FOO" },
+        },
+      },
     },
   },
 }
@@ -146,17 +155,45 @@ string keys), never both. Overseer components like
 so a `templates`/`generators` entry that carries nontrivial components
 can only be expressed this way.
 
-Each entry in `templates`/`generators` also accepts `after_target_args`, `env`,
-`metadata`, and `components`, which are merged into the
+Each entry in `templates`/`generators` also accepts `args`, `after_target_args`,
+`binary`, `env`, `metadata`, and `components`, which are merged into the
 `overseer.TaskDefinition` produced for that template/generated task (see
 `obazel.TemplateConfig` and `obazel.GeneratorConfig`). These are distinct
 from `template`/`template_file_definition`, which only affect the
 `overseer.TemplateDefinition` shown in `:OverseerRun`; fields like
 `components`, `env`, and `metadata` have no effect there, since they belong
-to the task, not the template.
+to the task, not the template. `args` and `binary` are both optional:
+omitting `args` produces a command with none (just `binary target` for
+generators), and omitting `binary` falls back to the top-level
+`bazel_binary`.
 
 The name of a generated task (from `generators`, not `templates`) starts
-with the tail of `config.bazel_binary` (e.g. `/usr/bin/bazelisk` becomes
-`bazelisk`), followed by `args`, the resolved target, and `after_target_args`,
-so task names stay accurate and distinct even when `bazel_binary` or
+with the tail of `binary` (its own `binary` if set, otherwise the tail of
+`config.bazel_binary`, e.g. `/usr/bin/bazelisk` becomes `bazelisk`),
+followed by `args`, the resolved target, and `after_target_args`, so task
+names stay accurate and distinct even when `binary`, `args`, or
 `after_target_args` differ between generator entries.
+
+Because `template`/`template_file_definition` are plain
+`overseer.TemplateDefinition`/`overseer.TemplateFileDefinition` tables, you
+can also supply your own `builder` there to fully replace obazel's. Doing so
+still gives you access to everything obazel would otherwise have used to
+build the task: `binary`, `args`, `after_target_args`, `env`, `metadata`,
+`components`, and (for `generators` only) the resolved `target`, via the
+`params` argument overseer passes to `builder(params)`:
+
+```lua
+{
+  query_template = "tests(%s:*)",
+  args = { "test" },
+  template_file_definition = {
+    builder = function(params)
+      return {
+        cmd = { params.binary },
+        args = { "test", params.target, "--test_output=all" },
+        env = params.env,
+      }
+    end,
+  },
+}
+```

--- a/README.md
+++ b/README.md
@@ -112,3 +112,25 @@ vim.g.obazel = {
   },
 }
 ```
+
+`vim.g.obazel` may also be set to a function that returns the config
+table, called lazily whenever obazel reads its configuration:
+
+```lua
+vim.g.obazel = function()
+  return {
+    overseer = {
+      templates = { ... },
+    },
+  }
+end
+```
+
+Only the function itself is stored in `vim.g.obazel`; its return value
+never passes through `vim.g`'s own value conversion. This matters because
+`vim.g` variables are round-tripped through Vimscript, which requires
+every table to be either a list (only integer keys) or a dict (only
+string keys), never both. Overseer components like
+`{ "on_output_parse", errorformat = "..." }` mix both in a single table,
+so a `templates`/`generators` entry that carries nontrivial components
+can only be expressed this way.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,17 @@ vim.g.obazel = {
         args = { "run", "//:gazelle" },
         template = { name = "bazel run //:gazelle" },
       },
+      {
+        args = { "test", "//..." },
+        -- Appended after the target (unlike `args`, which comes before it),
+        -- e.g. for flags you want passed through to the test binary itself
+        -- via `--`.
+        after_target_args = { "--", "--some-flag" },
+        env = { BAZEL_CONFIG = "ci" },
+        metadata = { kind = "test" },
+        components = { "default", { "on_output_parse", errorformat = "..." } },
+        template = { name = "bazel test //..." },
+      },
     },
     -- Task templates generated via bazel queries. The '%s' sign in the
     -- query_template will be replaced with the target_prefix, which is the
@@ -134,3 +145,18 @@ string keys), never both. Overseer components like
 `{ "on_output_parse", errorformat = "..." }` mix both in a single table,
 so a `templates`/`generators` entry that carries nontrivial components
 can only be expressed this way.
+
+Each entry in `templates`/`generators` also accepts `after_target_args`, `env`,
+`metadata`, and `components`, which are merged into the
+`overseer.TaskDefinition` produced for that template/generated task (see
+`obazel.TemplateConfig` and `obazel.GeneratorConfig`). These are distinct
+from `template`/`template_file_definition`, which only affect the
+`overseer.TemplateDefinition` shown in `:OverseerRun`; fields like
+`components`, `env`, and `metadata` have no effect there, since they belong
+to the task, not the template.
+
+The name of a generated task (from `generators`, not `templates`) starts
+with the tail of `config.bazel_binary` (e.g. `/usr/bin/bazelisk` becomes
+`bazelisk`), followed by `args`, the resolved target, and `after_target_args`,
+so task names stay accurate and distinct even when `bazel_binary` or
+`after_target_args` differ between generator entries.

--- a/README.md
+++ b/README.md
@@ -156,8 +156,8 @@ so a `templates`/`generators` entry that carries nontrivial components
 can only be expressed this way.
 
 Each entry in `templates`/`generators` also accepts `args`, `after_target_args`,
-`binary`, `env`, `metadata`, and `components`, which are merged into the
-`overseer.TaskDefinition` produced for that template/generated task (see
+`binary`, `cwd`, `env`, `metadata`, and `components`, which are merged into
+the `overseer.TaskDefinition` produced for that template/generated task (see
 `obazel.TemplateConfig` and `obazel.GeneratorConfig`). These are distinct
 from `template`/`template_file_definition`, which only affect the
 `overseer.TemplateDefinition` shown in `:OverseerRun`; fields like
@@ -166,6 +166,21 @@ to the task, not the template. `args` and `binary` are both optional:
 omitting `args` produces a command with none (just `binary target` for
 generators), and omitting `binary` falls back to the top-level
 `bazel_binary`.
+
+`cwd` sets the task's working directory. It defaults to the resolved bazel
+workspace root, and can be overridden with a fixed string or a function that
+takes the workspace root and returns the directory to use, e.g. to fall
+back to Neovim's own cwd instead:
+
+```lua
+{
+  args = { "run", "//:gazelle" },
+  cwd = function(workspace_root)
+    return vim.fn.getcwd()
+  end,
+  template = { name = "bazel run //:gazelle" },
+}
+```
 
 The name of a generated task (from `generators`, not `templates`) starts
 with the tail of `binary` (its own `binary` if set, otherwise the tail of
@@ -178,7 +193,7 @@ Because `template`/`template_file_definition` are plain
 `overseer.TemplateDefinition`/`overseer.TemplateFileDefinition` tables, you
 can also supply your own `builder` there to fully replace obazel's. Doing so
 still gives you access to everything obazel would otherwise have used to
-build the task: `binary`, `args`, `after_target_args`, `env`, `metadata`,
+build the task: `binary`, `args`, `after_target_args`, `cwd`, `env`, `metadata`,
 `components`, and (for `generators` only) the resolved `target`, via the
 `params` argument overseer passes to `builder(params)`:
 

--- a/README.md
+++ b/README.md
@@ -156,10 +156,11 @@ so a `templates`/`generators` entry that carries nontrivial components
 can only be expressed this way.
 
 Each entry in `templates`/`generators` also accepts `args`, `after_target_args`,
-`binary`, `cwd`, `env`, `metadata`, and `components`, which are merged into
-the `overseer.TaskDefinition` produced for that template/generated task (see
-`obazel.TemplateConfig` and `obazel.GeneratorConfig`). These are distinct
-from `template`/`template_file_definition`, which only affect the
+`binary`, `cwd`, `env`, `metadata`, `components`, and `relative_file_root`,
+which are merged into the `overseer.TaskDefinition` produced for that
+template/generated task (see `obazel.TemplateConfig` and
+`obazel.GeneratorConfig`). These are distinct from
+`template`/`template_file_definition`, which only affect the
 `overseer.TemplateDefinition` shown in `:OverseerRun`; fields like
 `components`, `env`, and `metadata` have no effect there, since they belong
 to the task, not the template. `args` and `binary` are both optional:
@@ -167,10 +168,12 @@ omitting `args` produces a command with none (just `binary target` for
 generators), and omitting `binary` falls back to the top-level
 `bazel_binary`.
 
-`cwd` sets the task's working directory. It defaults to the resolved bazel
-workspace root, and can be overridden with a fixed string or a function that
-takes the workspace root and returns the directory to use, e.g. to fall
-back to Neovim's own cwd instead:
+`cwd` sets the task's working directory, and `relative_file_root` is used to
+resolve relative paths reported by components like `on_output_parse` (e.g.
+compiler diagnostics). Both default to the resolved bazel workspace root, and
+both can be overridden with a fixed string or a function that takes the
+workspace root and returns the path to use, e.g. to fall back to Neovim's
+own cwd instead:
 
 ```lua
 {
@@ -181,6 +184,14 @@ back to Neovim's own cwd instead:
   template = { name = "bazel run //:gazelle" },
 }
 ```
+
+`relative_file_root` is resolved independently of `cwd`, and does *not* fall
+back to task `cwd` when left unset the way overseer's own `relative_file_root`
+component param does. Bazel's own diagnostics are reported relative to the
+workspace root regardless of where the task actually runs, so if you override
+`cwd` (e.g. to run a task from Neovim's cwd, as above) without also touching
+`relative_file_root`, diagnostics still resolve against the workspace root,
+which is almost always what you want.
 
 The name of a generated task (from `generators`, not `templates`) starts
 with the tail of `binary` (its own `binary` if set, otherwise the tail of
@@ -194,8 +205,8 @@ Because `template`/`template_file_definition` are plain
 can also supply your own `builder` there to fully replace obazel's. Doing so
 still gives you access to everything obazel would otherwise have used to
 build the task: `binary`, `args`, `after_target_args`, `cwd`, `env`, `metadata`,
-`components`, and (for `generators` only) the resolved `target`, via the
-`params` argument overseer passes to `builder(params)`:
+`components`, `relative_file_root`, and (for `generators` only) the resolved
+`target`, via the `params` argument overseer passes to `builder(params)`:
 
 ```lua
 {

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ vim.g.obazel = {
     templates = {
       {
         args = { "run", "//:gazelle" },
-        template = { name = "bazel run //:gazelle", priority = 50 },
+        template = { name = "bazel run //:gazelle" },
       },
     },
     -- Task templates generated via bazel queries. The '%s' sign in the
@@ -92,7 +92,6 @@ vim.g.obazel = {
         args = { "test" },
         template_file_definition = {
           tags = { "TEST" },
-          priority = 51,
         },
       },
       {
@@ -100,7 +99,6 @@ vim.g.obazel = {
         args = { "run" },
         template_file_definition = {
           tags = { "RUN" },
-          priority = 52,
         },
       },
       {
@@ -108,7 +106,6 @@ vim.g.obazel = {
         args = { "build" },
         template_file_definition = {
           tags = { "BUILD" },
-          priority = 100,
         },
       },
     },

--- a/doc/obazel.nvim.txt
+++ b/doc/obazel.nvim.txt
@@ -26,7 +26,6 @@ The template provider will need to be registered with overseer:
      }
 
 See:
-     |overseer.wrap_template|
      https://github.com/stevearc/overseer.nvim/blob/master/doc/guides.md
 
 ==============================================================================
@@ -56,7 +55,7 @@ Example configuration
          templates = {
            {
              args = { "run", "//:gazelle" },
-             template = { name = "bazel run //:gazelle", priority = 50 },
+             template = { name = "bazel run //:gazelle" },
            },
          },
          -- task templates generated via bazel queries
@@ -66,7 +65,6 @@ Example configuration
              args = { "test" },
              template_file_definition = {
                tags = { "TEST" },
-               priority = 51,
              },
            },
            {
@@ -74,7 +72,6 @@ Example configuration
              args = { "run" },
              template_file_definition = {
                tags = { "RUN" },
-               priority = 52,
              },
            },
            {
@@ -82,7 +79,6 @@ Example configuration
              args = { "build" },
              template_file_definition = {
                tags = { "BUILD" },
-               priority = 100,
              },
            },
          },
@@ -108,11 +104,11 @@ obazel.TemplateConfig                                    *obazel.TemplateConfig*
     A static template definition for bazel targets that you always want to have
     available. For example `bazel run //:gazelle`.
 
-    Use the `template` argument to set the `name` and `priority` of the task:
+    Use the `template` argument to set the `name` of the task:
     >lua
          {
              args = { "run", "//:gazelle" },
-             template = { name = "bazel run //:gazelle", priority = 50 },
+             template = { name = "bazel run //:gazelle" },
          }
 
     Fields: ~
@@ -135,7 +131,6 @@ obazel.GeneratorConfig                                  *obazel.GeneratorConfig*
            args = { "test" },
            template_file_definition = {
              tags = { "TEST" },
-             priority = 51,
            },
          }
 
@@ -145,7 +140,7 @@ obazel.GeneratorConfig                                  *obazel.GeneratorConfig*
         {template_file_definition?}  (table)     (optional) overrides values in the base overseer.TemplateFileDefinition
 
     See: ~
-        |overseer.wrap_template|
+        |overseer.TemplateFileDefinition|
 
 
 ==============================================================================
@@ -158,6 +153,8 @@ Utilities for working with Bazel workspaces
                                       *obazel-nvim.bazel.resolve_workspace_file*
 bazel.resolve_workspace_file({directory})
     Resolves the WORKSPACE file path
+    Recognises MODULE.bazel, REPO.bazel (Bzlmod), WORKSPACE.bazel, and WORKSPACE
+    as workspace root markers, checked in that order of preference.
 
     Parameters: ~
         {directory}  (nil|string)  (default: vim.fn.getcwd())
@@ -178,7 +175,8 @@ bazel.resolve_workspace_dir({directory})
 
 
 bazel.resolve_buildfile({directory})       *obazel-nvim.bazel.resolve_buildfile*
-    Resolves the nearest BUILD.bazel file from the given directory
+    Resolves the nearest BUILD or BUILD.bazel file from the given directory
+    Prefers BUILD.bazel if both exist in the same directory
 
     Parameters: ~
         {directory}  (string)
@@ -205,19 +203,16 @@ bazel.resolve_target_prefix({directory})
         (nil|string)  error_message
 
 
-bazel.query({query})                                   *obazel-nvim.bazel.query*
-    Run a bazel query
+bazel.query({query}, {callback})                       *obazel-nvim.bazel.query*
+    Run a bazel query asynchronously
 
     Parameters: ~
-        {query}  (string)
-
-    Returns: ~
-        (string[])    targets
-        (nil|string)  error_message
+        {query}     (string)
+        {callback}  (fun(targets:string[],error_message:string|nil))
 
     Usage: ~
 >lua
-        bazel.query("//foo/bar/...")
+        bazel.query("//foo/bar/...", function(targets, err) ... end)
 <
 
 

--- a/doc/obazel.nvim.txt
+++ b/doc/obazel.nvim.txt
@@ -132,13 +132,14 @@ obazel.TemplateConfig                                    *obazel.TemplateConfig*
          }
 
     Fields: ~
-        {args?}               (string[])                     (optional) the args that will be passed to bazel; omit for none, e.g. `binary target`
-        {after_target_args?}  (string[])                     (optional) args appended after `args`, e.g. for flags to pass through to the target itself via `--`
-        {binary?}             (string)                       (optional) override the configured `bazel_binary` for this template
-        {env?}                (table<string,string>)         (optional) environment variables for the task
-        {metadata?}           (table)                        (optional) arbitrary metadata for the task
-        {components?}         (overseer.Serialized[])        (optional) overseer components for the task
-        {template}            (overseer.TemplateDefinition)  the template definition
+        {args?}               (string[])                                  (optional) the args that will be passed to bazel; omit for none, e.g. `binary target`
+        {after_target_args?}  (string[])                                  (optional) args appended after `args`, e.g. for flags to pass through to the target itself via `--`
+        {binary?}             (string)                                    (optional) override the configured `bazel_binary` for this template
+        {cwd?}                (string|fun(workspace_root:string):string)  (optional) task working directory, or a function of the resolved bazel workspace root that returns one; defaults to the workspace root
+        {env?}                (table<string,string>)                      (optional) environment variables for the task
+        {metadata?}           (table)                                     (optional) arbitrary metadata for the task
+        {components?}         (overseer.Serialized[])                     (optional) overseer components for the task
+        {template}            (overseer.TemplateDefinition)               the template definition
 
 
 obazel.GeneratorConfig                                  *obazel.GeneratorConfig*
@@ -160,14 +161,15 @@ obazel.GeneratorConfig                                  *obazel.GeneratorConfig*
          }
 
     Fields: ~
-        {query_template}             (string)                 a query template where '%s' will be replaced by the target_prefix
-        {args?}                      (string[])               (optional) args that will be passed to bazel before the targets; omit for none, e.g. `binary target`
-        {after_target_args?}         (string[])               (optional) args appended after the resolved target, e.g. for flags to pass through to the target itself via `--`
-        {binary?}                    (string)                 (optional) override the configured `bazel_binary` for generated tasks
-        {env?}                       (table<string,string>)   (optional) environment variables for generated tasks
-        {metadata?}                  (table)                  (optional) arbitrary metadata for generated tasks
-        {components?}                (overseer.Serialized[])  (optional) overseer components for generated tasks
-        {template_file_definition?}  (table)                  (optional) overrides values in the base overseer.TemplateFileDefinition
+        {query_template}             (string)                                    a query template where '%s' will be replaced by the target_prefix
+        {args?}                      (string[])                                  (optional) args that will be passed to bazel before the targets; omit for none, e.g. `binary target`
+        {after_target_args?}         (string[])                                  (optional) args appended after the resolved target, e.g. for flags to pass through to the target itself via `--`
+        {binary?}                    (string)                                    (optional) override the configured `bazel_binary` for generated tasks
+        {cwd?}                       (string|fun(workspace_root:string):string)  (optional) task working directory, or a function of the resolved bazel workspace root that returns one; defaults to the workspace root
+        {env?}                       (table<string,string>)                      (optional) environment variables for generated tasks
+        {metadata?}                  (table)                                     (optional) arbitrary metadata for generated tasks
+        {components?}                (overseer.Serialized[])                     (optional) overseer components for generated tasks
+        {template_file_definition?}  (table)                                     (optional) overrides values in the base overseer.TemplateFileDefinition
 
     See: ~
         |overseer.TemplateFileDefinition|

--- a/doc/obazel.nvim.txt
+++ b/doc/obazel.nvim.txt
@@ -132,8 +132,12 @@ obazel.TemplateConfig                                    *obazel.TemplateConfig*
          }
 
     Fields: ~
-        {args}      (string[])                     the args that will be passed to bazel
-        {template}  (overseer.TemplateDefinition)  the template definition
+        {args}                (string[])                     the args that will be passed to bazel
+        {after_target_args?}  (string[])                     (optional) args appended after `args`, e.g. for flags to pass through to the target itself via `--`
+        {env?}                (table<string,string>)         (optional) environment variables for the task
+        {metadata?}           (table)                        (optional) arbitrary metadata for the task
+        {components?}         (overseer.Serialized[])        (optional) overseer components for the task
+        {template}            (overseer.TemplateDefinition)  the template definition
 
 
 obazel.GeneratorConfig                                  *obazel.GeneratorConfig*
@@ -155,9 +159,13 @@ obazel.GeneratorConfig                                  *obazel.GeneratorConfig*
          }
 
     Fields: ~
-        {query_template}             (string)    a query template where '%s' will be replaced by the target_prefix
-        {args}                       (string[])  args that will be passed to bazel before the targets
-        {template_file_definition?}  (table)     (optional) overrides values in the base overseer.TemplateFileDefinition
+        {query_template}             (string)                 a query template where '%s' will be replaced by the target_prefix
+        {args}                       (string[])               args that will be passed to bazel before the targets
+        {after_target_args?}         (string[])               (optional) args appended after the resolved target, e.g. for flags to pass through to the target itself via `--`
+        {env?}                       (table<string,string>)   (optional) environment variables for generated tasks
+        {metadata?}                  (table)                  (optional) arbitrary metadata for generated tasks
+        {components?}                (overseer.Serialized[])  (optional) overseer components for generated tasks
+        {template_file_definition?}  (table)                  (optional) overrides values in the base overseer.TemplateFileDefinition
 
     See: ~
         |overseer.TemplateFileDefinition|

--- a/doc/obazel.nvim.txt
+++ b/doc/obazel.nvim.txt
@@ -132,14 +132,15 @@ obazel.TemplateConfig                                    *obazel.TemplateConfig*
          }
 
     Fields: ~
-        {args?}               (string[])                                  (optional) the args that will be passed to bazel; omit for none, e.g. `binary target`
-        {after_target_args?}  (string[])                                  (optional) args appended after `args`, e.g. for flags to pass through to the target itself via `--`
-        {binary?}             (string)                                    (optional) override the configured `bazel_binary` for this template
-        {cwd?}                (string|fun(workspace_root:string):string)  (optional) task working directory, or a function of the resolved bazel workspace root that returns one; defaults to the workspace root
-        {env?}                (table<string,string>)                      (optional) environment variables for the task
-        {metadata?}           (table)                                     (optional) arbitrary metadata for the task
-        {components?}         (overseer.Serialized[])                     (optional) overseer components for the task
-        {template}            (overseer.TemplateDefinition)               the template definition
+        {args?}                (string[])                                  (optional) the args that will be passed to bazel; omit for none, e.g. `binary target`
+        {after_target_args?}   (string[])                                  (optional) args appended after `args`, e.g. for flags to pass through to the target itself via `--`
+        {binary?}              (string)                                    (optional) override the configured `bazel_binary` for this template
+        {cwd?}                 (string|fun(workspace_root:string):string)  (optional) task working directory, or a function of the resolved bazel workspace root that returns one; defaults to the workspace root
+        {env?}                 (table<string,string>)                      (optional) environment variables for the task
+        {metadata?}            (table)                                     (optional) arbitrary metadata for the task
+        {components?}          (overseer.Serialized[])                     (optional) overseer components for the task
+        {relative_file_root?}  (string|fun(workspace_root:string):string)  (optional) root for resolving relative paths reported by output-parsing components (e.g. compiler diagnostics), or a function of the resolved bazel workspace root that returns one; defaults to the workspace root. Unlike overseer's own `relative_file_root` param, this does *not* fall back to task `cwd` when unset: bazel's own diagnostics are reported relative to the workspace root regardless of `cwd`, so obazel pins this independently rather than letting it silently track a `cwd` override.
+        {template}             (overseer.TemplateDefinition)               the template definition
 
 
 obazel.GeneratorConfig                                  *obazel.GeneratorConfig*
@@ -169,6 +170,7 @@ obazel.GeneratorConfig                                  *obazel.GeneratorConfig*
         {env?}                       (table<string,string>)                      (optional) environment variables for generated tasks
         {metadata?}                  (table)                                     (optional) arbitrary metadata for generated tasks
         {components?}                (overseer.Serialized[])                     (optional) overseer components for generated tasks
+        {relative_file_root?}        (string|fun(workspace_root:string):string)  (optional) root for resolving relative paths reported by output-parsing components (e.g. compiler diagnostics), or a function of the resolved bazel workspace root that returns one; defaults to the workspace root. Unlike overseer's own `relative_file_root` param, this does *not* fall back to task `cwd` when unset: bazel's own diagnostics are reported relative to the workspace root regardless of `cwd`, so obazel pins this independently rather than letting it silently track a `cwd` override.
         {template_file_definition?}  (table)                                     (optional) overrides values in the base overseer.TemplateFileDefinition
 
     See: ~

--- a/doc/obazel.nvim.txt
+++ b/doc/obazel.nvim.txt
@@ -132,8 +132,9 @@ obazel.TemplateConfig                                    *obazel.TemplateConfig*
          }
 
     Fields: ~
-        {args}                (string[])                     the args that will be passed to bazel
+        {args?}               (string[])                     (optional) the args that will be passed to bazel; omit for none, e.g. `binary target`
         {after_target_args?}  (string[])                     (optional) args appended after `args`, e.g. for flags to pass through to the target itself via `--`
+        {binary?}             (string)                       (optional) override the configured `bazel_binary` for this template
         {env?}                (table<string,string>)         (optional) environment variables for the task
         {metadata?}           (table)                        (optional) arbitrary metadata for the task
         {components?}         (overseer.Serialized[])        (optional) overseer components for the task
@@ -160,8 +161,9 @@ obazel.GeneratorConfig                                  *obazel.GeneratorConfig*
 
     Fields: ~
         {query_template}             (string)                 a query template where '%s' will be replaced by the target_prefix
-        {args}                       (string[])               args that will be passed to bazel before the targets
+        {args?}                      (string[])               (optional) args that will be passed to bazel before the targets; omit for none, e.g. `binary target`
         {after_target_args?}         (string[])               (optional) args appended after the resolved target, e.g. for flags to pass through to the target itself via `--`
+        {binary?}                    (string)                 (optional) override the configured `bazel_binary` for generated tasks
         {env?}                       (table<string,string>)   (optional) environment variables for generated tasks
         {metadata?}                  (table)                  (optional) arbitrary metadata for generated tasks
         {components?}                (overseer.Serialized[])  (optional) overseer components for generated tasks

--- a/doc/obazel.nvim.txt
+++ b/doc/obazel.nvim.txt
@@ -85,6 +85,26 @@ Example configuration
        },
      }
 
+`vim.g.obazel` may also be set to a function that returns the config
+table, called lazily whenever obazel reads its configuration:
+>lua
+     vim.g.obazel = function()
+       return {
+         overseer = {
+           templates = { ... },
+         },
+       }
+     end
+
+Only the function itself is stored in `vim.g.obazel`; its return value
+never passes through `vim.g`'s own value conversion. This matters
+because `vim.g` variables are round-tripped through Vimscript, which
+requires every table to be either a list (only integer keys) or a dict
+(only string keys), never both. Overseer components like
+`{ "on_output_parse", errorformat = "..." }` mix both in a single
+table, so a `templates`/`generators` entry that carries nontrivial
+components can only be expressed this way.
+
 
 obazel.Config                                                    *obazel.Config*
 

--- a/lua/obazel/config/init.lua
+++ b/lua/obazel/config/init.lua
@@ -91,6 +91,10 @@
 ---     }
 ---@class obazel.TemplateConfig
 ---@field args string[] the args that will be passed to bazel
+---@field after_target_args? string[] (optional) args appended after `args`, e.g. for flags to pass through to the target itself via `--`
+---@field env? table<string, string> (optional) environment variables for the task
+---@field metadata? table (optional) arbitrary metadata for the task
+---@field components? overseer.Serialized[] (optional) overseer components for the task
 ---@field template overseer.TemplateDefinition the template definition
 
 ---A template generator using a bazel query.
@@ -112,6 +116,10 @@
 ---@class obazel.GeneratorConfig
 ---@field query_template string a query template where '%s' will be replaced by the target_prefix
 ---@field args string[] args that will be passed to bazel before the targets
+---@field after_target_args? string[] (optional) args appended after the resolved target, e.g. for flags to pass through to the target itself via `--`
+---@field env? table<string, string> (optional) environment variables for generated tasks
+---@field metadata? table (optional) arbitrary metadata for generated tasks
+---@field components? overseer.Serialized[] (optional) overseer components for generated tasks
 ---@field template_file_definition? table (optional) overrides values in the base overseer.TemplateFileDefinition
 ---@see overseer.TemplateFileDefinition
 

--- a/lua/obazel/config/init.lua
+++ b/lua/obazel/config/init.lua
@@ -50,6 +50,26 @@
 ---       },
 ---     }
 ---
+---`vim.g.obazel` may also be set to a function that returns the config
+---table, called lazily whenever obazel reads its configuration:
+--->lua
+---     vim.g.obazel = function()
+---       return {
+---         overseer = {
+---           templates = { ... },
+---         },
+---       }
+---     end
+---
+---Only the function itself is stored in `vim.g.obazel`; its return value
+---never passes through `vim.g`'s own value conversion. This matters
+---because `vim.g` variables are round-tripped through Vimscript, which
+---requires every table to be either a list (only integer keys) or a dict
+---(only string keys), never both. Overseer components like
+---`{ "on_output_parse", errorformat = "..." }` mix both in a single
+---table, so a `templates`/`generators` entry that carries nontrivial
+---components can only be expressed this way.
+---
 ---@brief ]]
 
 ---@class obazel.Config

--- a/lua/obazel/config/init.lua
+++ b/lua/obazel/config/init.lua
@@ -97,6 +97,7 @@
 ---@field env? table<string, string> (optional) environment variables for the task
 ---@field metadata? table (optional) arbitrary metadata for the task
 ---@field components? overseer.Serialized[] (optional) overseer components for the task
+---@field relative_file_root? string|fun(workspace_root: string): string (optional) root for resolving relative paths reported by output-parsing components (e.g. compiler diagnostics), or a function of the resolved bazel workspace root that returns one; defaults to the workspace root. Unlike overseer's own `relative_file_root` param, this does *not* fall back to task `cwd` when unset: bazel's own diagnostics are reported relative to the workspace root regardless of `cwd`, so obazel pins this independently rather than letting it silently track a `cwd` override.
 ---@field template overseer.TemplateDefinition the template definition
 
 ---A template generator using a bazel query.
@@ -124,6 +125,7 @@
 ---@field env? table<string, string> (optional) environment variables for generated tasks
 ---@field metadata? table (optional) arbitrary metadata for generated tasks
 ---@field components? overseer.Serialized[] (optional) overseer components for generated tasks
+---@field relative_file_root? string|fun(workspace_root: string): string (optional) root for resolving relative paths reported by output-parsing components (e.g. compiler diagnostics), or a function of the resolved bazel workspace root that returns one; defaults to the workspace root. Unlike overseer's own `relative_file_root` param, this does *not* fall back to task `cwd` when unset: bazel's own diagnostics are reported relative to the workspace root regardless of `cwd`, so obazel pins this independently rather than letting it silently track a `cwd` override.
 ---@field template_file_definition? table (optional) overrides values in the base overseer.TemplateFileDefinition
 ---@see overseer.TemplateFileDefinition
 

--- a/lua/obazel/config/init.lua
+++ b/lua/obazel/config/init.lua
@@ -90,8 +90,9 @@
 ---         template = { name = "bazel run //:gazelle" },
 ---     }
 ---@class obazel.TemplateConfig
----@field args string[] the args that will be passed to bazel
+---@field args? string[] (optional) the args that will be passed to bazel; omit for none, e.g. `binary target`
 ---@field after_target_args? string[] (optional) args appended after `args`, e.g. for flags to pass through to the target itself via `--`
+---@field binary? string (optional) override the configured `bazel_binary` for this template
 ---@field env? table<string, string> (optional) environment variables for the task
 ---@field metadata? table (optional) arbitrary metadata for the task
 ---@field components? overseer.Serialized[] (optional) overseer components for the task
@@ -115,8 +116,9 @@
 ---     }
 ---@class obazel.GeneratorConfig
 ---@field query_template string a query template where '%s' will be replaced by the target_prefix
----@field args string[] args that will be passed to bazel before the targets
+---@field args? string[] (optional) args that will be passed to bazel before the targets; omit for none, e.g. `binary target`
 ---@field after_target_args? string[] (optional) args appended after the resolved target, e.g. for flags to pass through to the target itself via `--`
+---@field binary? string (optional) override the configured `bazel_binary` for generated tasks
 ---@field env? table<string, string> (optional) environment variables for generated tasks
 ---@field metadata? table (optional) arbitrary metadata for generated tasks
 ---@field components? overseer.Serialized[] (optional) overseer components for generated tasks

--- a/lua/obazel/config/init.lua
+++ b/lua/obazel/config/init.lua
@@ -93,6 +93,7 @@
 ---@field args? string[] (optional) the args that will be passed to bazel; omit for none, e.g. `binary target`
 ---@field after_target_args? string[] (optional) args appended after `args`, e.g. for flags to pass through to the target itself via `--`
 ---@field binary? string (optional) override the configured `bazel_binary` for this template
+---@field cwd? string|fun(workspace_root: string): string (optional) task working directory, or a function of the resolved bazel workspace root that returns one; defaults to the workspace root
 ---@field env? table<string, string> (optional) environment variables for the task
 ---@field metadata? table (optional) arbitrary metadata for the task
 ---@field components? overseer.Serialized[] (optional) overseer components for the task
@@ -119,6 +120,7 @@
 ---@field args? string[] (optional) args that will be passed to bazel before the targets; omit for none, e.g. `binary target`
 ---@field after_target_args? string[] (optional) args appended after the resolved target, e.g. for flags to pass through to the target itself via `--`
 ---@field binary? string (optional) override the configured `bazel_binary` for generated tasks
+---@field cwd? string|fun(workspace_root: string): string (optional) task working directory, or a function of the resolved bazel workspace root that returns one; defaults to the workspace root
 ---@field env? table<string, string> (optional) environment variables for generated tasks
 ---@field metadata? table (optional) arbitrary metadata for generated tasks
 ---@field components? overseer.Serialized[] (optional) overseer components for generated tasks

--- a/lua/overseer/template/obazel/init.lua
+++ b/lua/overseer/template/obazel/init.lua
@@ -58,6 +58,7 @@ function provider.generator(opts, cb)
         local metadata = template_config.metadata
         local components = template_config.components
         local cwd = resolve_workspace_relative(template_config.cwd, workspace_root)
+        local relative_file_root = resolve_workspace_relative(template_config.relative_file_root, workspace_root)
 
         table.insert(
             templates,
@@ -74,6 +75,7 @@ function provider.generator(opts, cb)
                     },
                     cwd = { type = "string", optional = true, default = cwd },
                     env = { type = "opaque", optional = true, default = template_config.env },
+                    relative_file_root = { type = "string", optional = true, default = relative_file_root },
                 },
                 builder = function(params)
                     vim.list_extend(params.args, params.after_target_args)
@@ -84,6 +86,12 @@ function provider.generator(opts, cb)
                         env = params.env,
                         metadata = metadata,
                         components = components,
+                        -- Picked up by any attached component whose param
+                        -- has `default_from_task = true`, e.g.
+                        -- `on_output_parse`'s `relative_file_root`, so
+                        -- relative diagnostic paths resolve against the
+                        -- bazel workspace root instead of task cwd.
+                        default_component_params = { relative_file_root = params.relative_file_root },
                     }
                 end,
             }, template_config.template)
@@ -108,6 +116,7 @@ function provider.generator(opts, cb)
         local metadata = query_config.metadata
         local components = query_config.components
         local cwd = resolve_workspace_relative(query_config.cwd, workspace_root)
+        local relative_file_root = resolve_workspace_relative(query_config.relative_file_root, workspace_root)
 
         bazel.query(query, function(targets, err2)
             if err2 ~= nil then
@@ -145,6 +154,11 @@ function provider.generator(opts, cb)
                                 },
                                 cwd = { type = "string", optional = true, default = cwd },
                                 env = { type = "opaque", optional = true, default = query_config.env },
+                                relative_file_root = {
+                                    type = "string",
+                                    optional = true,
+                                    default = relative_file_root,
+                                },
                             },
                             builder = function(params)
                                 local qargs = vim.deepcopy(params.args)
@@ -157,6 +171,7 @@ function provider.generator(opts, cb)
                                     env = params.env,
                                     metadata = metadata,
                                     components = components,
+                                    default_component_params = { relative_file_root = params.relative_file_root },
                                 }
                             end,
                         }, query_config.template_file_definition or {})

--- a/lua/overseer/template/obazel/init.lua
+++ b/lua/overseer/template/obazel/init.lua
@@ -42,26 +42,32 @@ function provider.generator(opts, cb)
     ---@type overseer.TemplateDefinition[]
     local templates = {}
 
-    -- Used for the generated task name below, e.g. "/usr/bin/bazelisk" -> "bazelisk"
-    local binary_tail = vim.fn.fnamemodify(config.bazel_binary, ":t")
-
     for _, template_config in ipairs(config.overseer.templates) do
-        local args = template_config.args
-        if template_config.after_target_args then
-            args = vim.list_extend(vim.deepcopy(args), template_config.after_target_args)
-        end
-        local env = template_config.env
+        local binary = template_config.binary or config.bazel_binary
         local metadata = template_config.metadata
         local components = template_config.components
 
         table.insert(
             templates,
             vim.tbl_deep_extend("force", {
-                builder = function()
+                ---@type overseer.Params
+                params = {
+                    binary = { type = "string", optional = true, default = binary },
+                    args = { type = "list", delimiter = " ", optional = true, default = template_config.args or {} },
+                    after_target_args = {
+                        type = "list",
+                        delimiter = " ",
+                        optional = true,
+                        default = template_config.after_target_args or {},
+                    },
+                    env = { type = "opaque", optional = true, default = template_config.env },
+                },
+                builder = function(params)
+                    vim.list_extend(params.args, params.after_target_args)
                     return {
-                        cmd = { config.bazel_binary },
-                        args = args,
-                        env = env,
+                        cmd = { params.binary },
+                        args = params.args,
+                        env = params.env,
                         metadata = metadata,
                         components = components,
                     }
@@ -80,6 +86,13 @@ function provider.generator(opts, cb)
 
     for _, query_config in ipairs(generators) do
         local query = query_config.query_template:format(target_prefix)
+        local binary = query_config.binary or config.bazel_binary
+        -- Used for the generated task name below, e.g. "/usr/bin/bazelisk" -> "bazelisk"
+        local binary_tail = vim.fn.fnamemodify(binary, ":t")
+        local args = query_config.args or {}
+        local after_target_args = query_config.after_target_args or {}
+        local metadata = query_config.metadata
+        local components = query_config.components
 
         bazel.query(query, function(targets, err2)
             if err2 ~= nil then
@@ -88,33 +101,43 @@ function provider.generator(opts, cb)
                 for _, target in ipairs(targets) do
                     -- TODO toggleable in config to show short or long targets?
                     local short_target = remove_prefix(target, target_prefix)
-                    local qargs = vim.list_extend(vim.deepcopy(query_config.args), { target })
-                    if query_config.after_target_args then
-                        vim.list_extend(qargs, query_config.after_target_args)
-                    end
-                    local env = query_config.env
-                    local metadata = query_config.metadata
-                    local components = query_config.components
 
-                    -- Mirrors the order of `cmd`/`qargs` below (binary, base
-                    -- args, target, after_target_args), but with `short_target`
-                    -- in place of the fully-qualified target for readability.
+                    -- Mirrors the order of the args built in `builder` below
+                    -- (binary, base args, target, after_target_args), but with
+                    -- `short_target` in place of the fully-qualified target
+                    -- for readability. `args`/`after_target_args` default to
+                    -- {}, so an entry with neither set produces just
+                    -- "binary target", e.g. "foo //blah/blah:target".
                     local name_parts = { binary_tail }
-                    vim.list_extend(name_parts, query_config.args)
+                    vim.list_extend(name_parts, args)
                     table.insert(name_parts, short_target)
-                    if query_config.after_target_args then
-                        vim.list_extend(name_parts, query_config.after_target_args)
-                    end
+                    vim.list_extend(name_parts, after_target_args)
 
                     table.insert(
                         templates,
                         vim.tbl_deep_extend("force", {
                             name = table.concat(name_parts, " "),
-                            builder = function()
+                            ---@type overseer.Params
+                            params = {
+                                binary = { type = "string", optional = true, default = binary },
+                                args = { type = "list", delimiter = " ", optional = true, default = args },
+                                target = { type = "string", optional = true, default = target },
+                                after_target_args = {
+                                    type = "list",
+                                    delimiter = " ",
+                                    optional = true,
+                                    default = after_target_args,
+                                },
+                                env = { type = "opaque", optional = true, default = query_config.env },
+                            },
+                            builder = function(params)
+                                local qargs = vim.deepcopy(params.args)
+                                table.insert(qargs, params.target)
+                                vim.list_extend(qargs, params.after_target_args)
                                 return {
-                                    cmd = { config.bazel_binary },
+                                    cmd = { params.binary },
                                     args = qargs,
-                                    env = env,
+                                    env = params.env,
                                     metadata = metadata,
                                     components = components,
                                 }

--- a/lua/overseer/template/obazel/init.lua
+++ b/lua/overseer/template/obazel/init.lua
@@ -42,8 +42,18 @@ function provider.generator(opts, cb)
     ---@type overseer.TemplateDefinition[]
     local templates = {}
 
+    -- Used for the generated task name below, e.g. "/usr/bin/bazelisk" -> "bazelisk"
+    local binary_tail = vim.fn.fnamemodify(config.bazel_binary, ":t")
+
     for _, template_config in ipairs(config.overseer.templates) do
         local args = template_config.args
+        if template_config.after_target_args then
+            args = vim.list_extend(vim.deepcopy(args), template_config.after_target_args)
+        end
+        local env = template_config.env
+        local metadata = template_config.metadata
+        local components = template_config.components
+
         table.insert(
             templates,
             vim.tbl_deep_extend("force", {
@@ -51,6 +61,9 @@ function provider.generator(opts, cb)
                     return {
                         cmd = { config.bazel_binary },
                         args = args,
+                        env = env,
+                        metadata = metadata,
+                        components = components,
                     }
                 end,
             }, template_config.template)
@@ -76,15 +89,34 @@ function provider.generator(opts, cb)
                     -- TODO toggleable in config to show short or long targets?
                     local short_target = remove_prefix(target, target_prefix)
                     local qargs = vim.list_extend(vim.deepcopy(query_config.args), { target })
+                    if query_config.after_target_args then
+                        vim.list_extend(qargs, query_config.after_target_args)
+                    end
+                    local env = query_config.env
+                    local metadata = query_config.metadata
+                    local components = query_config.components
+
+                    -- Mirrors the order of `cmd`/`qargs` below (binary, base
+                    -- args, target, after_target_args), but with `short_target`
+                    -- in place of the fully-qualified target for readability.
+                    local name_parts = { binary_tail }
+                    vim.list_extend(name_parts, query_config.args)
+                    table.insert(name_parts, short_target)
+                    if query_config.after_target_args then
+                        vim.list_extend(name_parts, query_config.after_target_args)
+                    end
 
                     table.insert(
                         templates,
                         vim.tbl_deep_extend("force", {
-                            name = ("bazel %s %s"):format(table.concat(query_config.args, " "), short_target),
+                            name = table.concat(name_parts, " "),
                             builder = function()
                                 return {
                                     cmd = { config.bazel_binary },
                                     args = qargs,
+                                    env = env,
+                                    metadata = metadata,
+                                    components = components,
                                 }
                             end,
                         }, query_config.template_file_definition or {})

--- a/lua/overseer/template/obazel/init.lua
+++ b/lua/overseer/template/obazel/init.lua
@@ -19,6 +19,16 @@ local function remove_prefix(str, prefix)
     end
 end
 
+---@param value string|fun(workspace_root: string):string|nil
+---@param workspace_root string
+---@return string
+local function resolve_workspace_relative(value, workspace_root)
+    if type(value) == "function" then
+        return value(workspace_root)
+    end
+    return value or workspace_root
+end
+
 ---@type overseer.TemplateProvider
 local provider = {
     name = "bazel",
@@ -38,6 +48,7 @@ function provider.generator(opts, cb)
     if err1 ~= nil then
         return err1
     end
+    local workspace_root = bazel.resolve_workspace_dir(opts.dir)
 
     ---@type overseer.TemplateDefinition[]
     local templates = {}
@@ -46,6 +57,7 @@ function provider.generator(opts, cb)
         local binary = template_config.binary or config.bazel_binary
         local metadata = template_config.metadata
         local components = template_config.components
+        local cwd = resolve_workspace_relative(template_config.cwd, workspace_root)
 
         table.insert(
             templates,
@@ -60,6 +72,7 @@ function provider.generator(opts, cb)
                         optional = true,
                         default = template_config.after_target_args or {},
                     },
+                    cwd = { type = "string", optional = true, default = cwd },
                     env = { type = "opaque", optional = true, default = template_config.env },
                 },
                 builder = function(params)
@@ -67,6 +80,7 @@ function provider.generator(opts, cb)
                     return {
                         cmd = { params.binary },
                         args = params.args,
+                        cwd = params.cwd,
                         env = params.env,
                         metadata = metadata,
                         components = components,
@@ -93,6 +107,7 @@ function provider.generator(opts, cb)
         local after_target_args = query_config.after_target_args or {}
         local metadata = query_config.metadata
         local components = query_config.components
+        local cwd = resolve_workspace_relative(query_config.cwd, workspace_root)
 
         bazel.query(query, function(targets, err2)
             if err2 ~= nil then
@@ -128,6 +143,7 @@ function provider.generator(opts, cb)
                                     optional = true,
                                     default = after_target_args,
                                 },
+                                cwd = { type = "string", optional = true, default = cwd },
                                 env = { type = "opaque", optional = true, default = query_config.env },
                             },
                             builder = function(params)
@@ -137,6 +153,7 @@ function provider.generator(opts, cb)
                                 return {
                                     cmd = { params.binary },
                                     args = qargs,
+                                    cwd = params.cwd,
                                     env = params.env,
                                     metadata = metadata,
                                     components = components,


### PR DESCRIPTION
 ## Summary
  - Add a `cwd` option to templates/generators, defaulting to the resolved bazel workspace root instead of Neovim's own cwd (**breaking**, see below)
  - Add a `relative_file_root` option, defaulting to the workspace root independently of `cwd`, wired into `on_output_parse`'s own `relative_file_root` param so diagnostic paths (e.g. compiler errors) resolve correctly regardless of where the task actually runs (added to `default_component_params` so that it is received by default by `on_output_diagnostic`, etc. components)

  Both accept a fixed string or a function of the resolved workspace root.

  ## Breaking change
  obazel-generated tasks now run from the bazel workspace root by default instead of Neovim's cwd. To restore the previous behavior on a given template/generator:
  ```lua
  cwd = function(workspace_root)
    return vim.fn.getcwd()
  end,
  ```

Fixes #19.

Depends on/contains all the commits from  #21 and #18 as well.