### PR TITLE
Documentation fixes missed in last few PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,25 @@ vim.g.obazel = {
   },
 }
 ```
+
+`vim.g.obazel` may also be set to a function that returns the config
+table, called lazily whenever obazel reads its configuration:
+
+```lua
+vim.g.obazel = function()
+  return {
+    overseer = {
+      templates = { ... },
+    },
+  }
+end
+```
+
+Only the function itself is stored in `vim.g.obazel`; its return value
+never passes through `vim.g`'s own value conversion. This matters because
+`vim.g` variables are round-tripped through Vimscript, which requires
+every table to be either a list (only integer keys) or a dict (only
+string keys), never both. Overseer components like
+`{ "on_output_parse", errorformat = "..." }` mix both in a single table,
+so a `templates`/`generators` entry that carries nontrivial components
+can only be expressed this way.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ vim.g.obazel = {
     templates = {
       {
         args = { "run", "//:gazelle" },
-        template = { name = "bazel run //:gazelle", priority = 50 },
+        template = { name = "bazel run //:gazelle" },
       },
     },
     -- Task templates generated via bazel queries. The '%s' sign in the
@@ -92,7 +92,6 @@ vim.g.obazel = {
         args = { "test" },
         template_file_definition = {
           tags = { "TEST" },
-          priority = 51,
         },
       },
       {
@@ -100,7 +99,6 @@ vim.g.obazel = {
         args = { "run" },
         template_file_definition = {
           tags = { "RUN" },
-          priority = 52,
         },
       },
       {
@@ -108,7 +106,6 @@ vim.g.obazel = {
         args = { "build" },
         template_file_definition = {
           tags = { "BUILD" },
-          priority = 100,
         },
       },
     },

--- a/doc/obazel.nvim.txt
+++ b/doc/obazel.nvim.txt
@@ -26,7 +26,6 @@ The template provider will need to be registered with overseer:
      }
 
 See:
-     |overseer.wrap_template|
      https://github.com/stevearc/overseer.nvim/blob/master/doc/guides.md
 
 ==============================================================================
@@ -56,7 +55,7 @@ Example configuration
          templates = {
            {
              args = { "run", "//:gazelle" },
-             template = { name = "bazel run //:gazelle", priority = 50 },
+             template = { name = "bazel run //:gazelle" },
            },
          },
          -- task templates generated via bazel queries
@@ -66,7 +65,6 @@ Example configuration
              args = { "test" },
              template_file_definition = {
                tags = { "TEST" },
-               priority = 51,
              },
            },
            {
@@ -74,7 +72,6 @@ Example configuration
              args = { "run" },
              template_file_definition = {
                tags = { "RUN" },
-               priority = 52,
              },
            },
            {
@@ -82,7 +79,6 @@ Example configuration
              args = { "build" },
              template_file_definition = {
                tags = { "BUILD" },
-               priority = 100,
              },
            },
          },
@@ -108,11 +104,11 @@ obazel.TemplateConfig                                    *obazel.TemplateConfig*
     A static template definition for bazel targets that you always want to have
     available. For example `bazel run //:gazelle`.
 
-    Use the `template` argument to set the `name` and `priority` of the task:
+    Use the `template` argument to set the `name` of the task:
     >lua
          {
              args = { "run", "//:gazelle" },
-             template = { name = "bazel run //:gazelle", priority = 50 },
+             template = { name = "bazel run //:gazelle" },
          }
 
     Fields: ~
@@ -135,7 +131,6 @@ obazel.GeneratorConfig                                  *obazel.GeneratorConfig*
            args = { "test" },
            template_file_definition = {
              tags = { "TEST" },
-             priority = 51,
            },
          }
 
@@ -145,7 +140,7 @@ obazel.GeneratorConfig                                  *obazel.GeneratorConfig*
         {template_file_definition?}  (table)     (optional) overrides values in the base overseer.TemplateFileDefinition
 
     See: ~
-        |overseer.wrap_template|
+        |overseer.TemplateFileDefinition|
 
 
 ==============================================================================
@@ -158,6 +153,8 @@ Utilities for working with Bazel workspaces
                                       *obazel-nvim.bazel.resolve_workspace_file*
 bazel.resolve_workspace_file({directory})
     Resolves the WORKSPACE file path
+    Recognises MODULE.bazel, REPO.bazel (Bzlmod), WORKSPACE.bazel, and WORKSPACE
+    as workspace root markers, checked in that order of preference.
 
     Parameters: ~
         {directory}  (nil|string)  (default: vim.fn.getcwd())
@@ -178,7 +175,8 @@ bazel.resolve_workspace_dir({directory})
 
 
 bazel.resolve_buildfile({directory})       *obazel-nvim.bazel.resolve_buildfile*
-    Resolves the nearest BUILD.bazel file from the given directory
+    Resolves the nearest BUILD or BUILD.bazel file from the given directory
+    Prefers BUILD.bazel if both exist in the same directory
 
     Parameters: ~
         {directory}  (string)
@@ -205,19 +203,16 @@ bazel.resolve_target_prefix({directory})
         (nil|string)  error_message
 
 
-bazel.query({query})                                   *obazel-nvim.bazel.query*
-    Run a bazel query
+bazel.query({query}, {callback})                       *obazel-nvim.bazel.query*
+    Run a bazel query asynchronously
 
     Parameters: ~
-        {query}  (string)
-
-    Returns: ~
-        (string[])    targets
-        (nil|string)  error_message
+        {query}     (string)
+        {callback}  (fun(targets:string[],error_message:string|nil))
 
     Usage: ~
 >lua
-        bazel.query("//foo/bar/...")
+        bazel.query("//foo/bar/...", function(targets, err) ... end)
 <
 
 

--- a/doc/obazel.nvim.txt
+++ b/doc/obazel.nvim.txt
@@ -85,6 +85,26 @@ Example configuration
        },
      }
 
+`vim.g.obazel` may also be set to a function that returns the config
+table, called lazily whenever obazel reads its configuration:
+>lua
+     vim.g.obazel = function()
+       return {
+         overseer = {
+           templates = { ... },
+         },
+       }
+     end
+
+Only the function itself is stored in `vim.g.obazel`; its return value
+never passes through `vim.g`'s own value conversion. This matters
+because `vim.g` variables are round-tripped through Vimscript, which
+requires every table to be either a list (only integer keys) or a dict
+(only string keys), never both. Overseer components like
+`{ "on_output_parse", errorformat = "..." }` mix both in a single
+table, so a `templates`/`generators` entry that carries nontrivial
+components can only be expressed this way.
+
 
 obazel.Config                                                    *obazel.Config*
 

--- a/lua/obazel/config/init.lua
+++ b/lua/obazel/config/init.lua
@@ -50,6 +50,26 @@
 ---       },
 ---     }
 ---
+---`vim.g.obazel` may also be set to a function that returns the config
+---table, called lazily whenever obazel reads its configuration:
+--->lua
+---     vim.g.obazel = function()
+---       return {
+---         overseer = {
+---           templates = { ... },
+---         },
+---       }
+---     end
+---
+---Only the function itself is stored in `vim.g.obazel`; its return value
+---never passes through `vim.g`'s own value conversion. This matters
+---because `vim.g` variables are round-tripped through Vimscript, which
+---requires every table to be either a list (only integer keys) or a dict
+---(only string keys), never both. Overseer components like
+---`{ "on_output_parse", errorformat = "..." }` mix both in a single
+---table, so a `templates`/`generators` entry that carries nontrivial
+---components can only be expressed this way.
+---
 ---@brief ]]
 
 ---@class obazel.Config


### PR DESCRIPTION
Regenerates the docs, removes stray `priority` fields from examples that are no longer part of the overseer API, document that `vim.g.obazel` can be set to a function that returns a table.